### PR TITLE
Better JPG Support, Bug Fixes (Image Type)

### DIFF
--- a/bin/ffmpeg.py
+++ b/bin/ffmpeg.py
@@ -82,11 +82,24 @@ class Ffmpeg:
 
         execute.extend(self._read_configuration(phase='video_to_frames'))
 
-        execute.extend([
-            '-i',
-            input_video,
-            f'{extracted_frames}\\extracted_%0d.{self.image_format}'
-        ])
+        # By default, extracting frames using jpg from ffmpeg
+        # will output the lowest jpg quality possible.
+        # The added arguments ensures the highest quality jpg possible.
+        if self.image_format == 'jpg':
+            execute.extend([
+                '-i',
+                input_video,
+                '-qscale:v',
+                '2',
+                f'{extracted_frames}\\extracted_%0d.{self.image_format}'
+            ])
+
+        else:
+            execute.extend([
+                '-i',
+                input_video,
+                f'{extracted_frames}\\extracted_%0d.{self.image_format}'
+            ])
 
         self._execute(execute)
 

--- a/bin/upscaler.py
+++ b/bin/upscaler.py
@@ -37,7 +37,7 @@ class Upscaler:
         ArgumentError -- if argument is not valid
     """
 
-    def __init__(self, input_video, output_video, method, waifu2x_settings, ffmpeg_settings):
+    def __init__(self, input_video, output_video, method, waifu2x_settings, ffmpeg_settings, image_format):
         # mandatory arguments
         self.input_video = input_video
         self.output_video = output_video
@@ -53,7 +53,7 @@ class Upscaler:
         self.model_dir = None
         self.threads = 5
         self.video2x_cache_directory = f'{tempfile.gettempdir()}\\video2x'
-        self.image_format = 'png'
+        self.image_format = image_format
         self.preserve_frames = False
 
     def create_temp_directories(self):
@@ -100,10 +100,9 @@ class Upscaler:
         # get number of extracted frames
         total_frames = 0
         for directory in extracted_frames_directories:
-            total_frames += len([f for f in os.listdir(directory) if f[-4:] == '.png'])
+            total_frames += len([f for f in os.listdir(directory) if f[-4:] == '.' + self.image_format])
 
         with tqdm(total=total_frames, ascii=True, desc='Upscaling Progress') as progress_bar:
-
             # tqdm update method adds the value to the progress
             # bar instead of setting the value. Therefore, a delta
             # needs to be calculated.
@@ -111,7 +110,7 @@ class Upscaler:
             while not self.progress_bar_exit_signal:
 
                 try:
-                    total_frames_upscaled = len([f for f in os.listdir(self.upscaled_frames) if f[-4:] == '.png'])
+                    total_frames_upscaled = len([f for f in os.listdir(self.upscaled_frames) if f[-4:] == '.' + self.image_format])
                     delta = total_frames_upscaled - previous_cycle_frames
                     previous_cycle_frames = total_frames_upscaled
 

--- a/bin/video2x.py
+++ b/bin/video2x.py
@@ -300,7 +300,7 @@ try:
             Avalon.error('Suffix must be specified for FFmpeg')
             raise Exception('No suffix specified')
 
-        upscaler = Upscaler(input_video=args.input, output_video=args.output, method=args.method, waifu2x_settings=waifu2x_settings, ffmpeg_settings=ffmpeg_settings)
+        upscaler = Upscaler(input_video=args.input, output_video=args.output, method=args.method, waifu2x_settings=waifu2x_settings, ffmpeg_settings=ffmpeg_settings, image_format = image_format)
 
         # set optional options
         upscaler.waifu2x_driver = args.driver


### PR DESCRIPTION
- Fixed bug where using alternative filetypes wouldn't be supported by CLI (CLI wouldn't show updates such as total frames remaining, etc for any filetype other than .png). Had to add 'image_type' as an argument to upscale for this to work, and replace some hard-coded variables with 'image_type' variable.

- Added FFMPEG flag to make FFMPEG extract JPG frames in the highest quality possible. (without 'qscale:v' flag, JPEG images would be extracted with the lowest setting possible)

(See https://stackoverflow.com/questions/10225403/how-can-i-extract-a-good-quality-jpeg-image-from-an-h264-video-file-with-ffmpeg)