### PR TITLE
Expand png bit-depth

### DIFF
--- a/bin/video2x.json
+++ b/bin/video2x.json
@@ -11,7 +11,7 @@
     "process": "gpu",
     "crop_size": 128,
     "output_quality": -1,
-    "output_depth": 8,
+    "output_depth": 16,
     "batch_size": 1,
     "gpu": 0,
     "tta": 0,
@@ -51,7 +51,8 @@
     "ffmpeg_path": "C:\\Users\\K4YT3X\\AppData\\Local\\video2x\\ffmpeg-latest-win64-static\\bin",
     "video_to_frames": {
       "output_options": {
-        "-qscale:v": null
+        "-qscale:v": null,
+        "-pix_fmt": "rgba64be"
       },
       "-hwaccel": "auto",
       "-y": true
@@ -66,7 +67,7 @@
         "-vcodec": "libx264",
         "-crf": 17,
         "-b:v": null,
-        "-pix_fmt": "yuv420p"
+        "-pix_fmt": "yuv422p"
       },
       "-y": true
     },
@@ -76,7 +77,7 @@
         "-map": "1?",
         "-c": "copy",
         "-map": "-1:v?",
-        "-pix_fmt": "yuv420p"
+        "-pix_fmt": "yuv422p"
       },
       "-y": true
     }


### PR DESCRIPTION
Should address #117.
Both `w2x-caffe` and `w2x-converter` will happily churn out a png with depth 64.
`w2x-ncnn` will output a png with depth 24 (w2x-ncnn limitation).