### PR TITLE
Video2X now supports all operating systems

### DIFF
--- a/bin/anime4k.py
+++ b/bin/anime4k.py
@@ -10,6 +10,9 @@ Description: This class is a high-level wrapper
 for Anime4k.
 """
 
+# local imports
+import common
+
 # built-in imports
 import subprocess
 import threading
@@ -27,8 +30,8 @@ class Anime4k:
     the upscale function.
     """
 
-    def __init__(self, waifu2x_settings):
-        self.waifu2x_settings = waifu2x_settings
+    def __init__(self, settings):
+        self.settings = settings
         self.print_lock = threading.Lock()
 
     def upscale(self, input_directory, output_directory, scale_ratio, upscaler_exceptions, push_strength=None, push_grad_strength=None):
@@ -57,9 +60,9 @@ class Anime4k:
             for image in extracted_frame_files:
 
                 execute = [
-                    self.waifu2x_settings['java_path'],
+                    self.settings['java_path'],
                     '-jar',
-                    self.waifu2x_settings['anime4k_path'],
+                    common.find_path(self.settings['path']),
                     str(image.absolute()),
                     str(output_directory / image.name),
                     str(scale_ratio)

--- a/bin/anime4k.py
+++ b/bin/anime4k.py
@@ -56,16 +56,19 @@ class Anime4k:
             # get a list lof all image files in input_directory
             extracted_frame_files = [f for f in input_directory.iterdir() if str(f).lower().endswith('.png') or str(f).lower().endswith('.jpg')]
 
+            # Only print debug_info on first iteration.
+            logged = False
+
             # upscale each image in input_directory
             for image in extracted_frame_files:
 
                 execute = [
-                    self.settings['java_path'],
+                    self.settings['java_path'] / self.settings['java_binary'],
                     '-jar',
-                    common.find_path(self.settings['path']),
-                    str(image.absolute()),
-                    str(output_directory / image.name),
-                    str(scale_ratio)
+                    self.settings['path'] / self.settings['binary'],
+                    image.absolute(),
+                    output_directory / image.name,
+                    scale_ratio
                 ]
 
                 # optional arguments
@@ -79,9 +82,15 @@ class Anime4k:
                     if locals()[arg] is not None:
                         execute.extend([locals([arg])])
 
-                self.print_lock.acquire()
-                Avalon.debug_info(f'Executing: {execute}', )
-                self.print_lock.release()
+                # turn all list elements into string to avoid errors
+                execute = [str(e) for e in execute]
+
+                if not logged:
+                    self.print_lock.acquire()
+                    Avalon.debug_info(f'Executing: {execute}', )
+                    self.print_lock.release()
+                    logged = True
+
                 return_value += subprocess.run(execute, check=True).returncode
 
             # print thread exiting message

--- a/bin/anime4k.py
+++ b/bin/anime4k.py
@@ -87,7 +87,7 @@ class Anime4k:
 
                 if not logged:
                     self.print_lock.acquire()
-                    Avalon.debug_info(f'Executing: {execute}', )
+                    Avalon.debug_info(f'Executing: {execute}')
                     self.print_lock.release()
                     logged = True
 

--- a/bin/common.py
+++ b/bin/common.py
@@ -9,36 +9,45 @@ Last Modified: Sept 15, 2019
 Description: This class contains helper functions.
 """
 
-import os
 from pathlib import Path
 import subprocess
+import shutil
 
 
 def find_path(path="", filename=""):
     """Looks for file in specified path. If not found, checks system path."""
-    current_path = Path(__file__).parent  # common.py's path
 
-    # Search in specified path
-    if os.path.exists(Path(path) / Path(filename + '.exe')):
-        return [Path(path), filename + '.exe']
-    elif os.path.exists(Path(path) / filename):
-        return [Path(path), filename]
+    # Search in calling path
+    if _find_file(path, filename):
+        return _find_file(path, filename)
+
+    # common.py's path
+    current_path = Path(__file__).parent
+
     # Search in common.py's path (usually bin folder)
-    if os.path.exists(current_path / path / Path(filename + '.exe')):
-        return [current_path / path, filename + '.exe']
-    elif os.path.exists(current_path / path / filename):
-        return [current_path / path, filename]
+    if _find_file(current_path / path, filename):
+        return _find_file(current_path / path, filename)
+
     # Search one directory back (usually video2x folder)
-    elif os.path.exists(current_path / '..' / path / Path(filename + '.exe')):
-        return [current_path / '..' / path, filename + '.exe']
-    elif os.path.exists(current_path / '..' / path / filename):
-        return [current_path / '..' / path, filename]
-    # Search for program in $PATH
-    elif filename:
-        if subprocess.run('command -v ' + filename + '.exe', shell=True, stdout=subprocess.DEVNULL).returncode == 0:
-            return [Path(""), filename + '.exe']
-        elif subprocess.run('command -v ' + filename, shell=True, stdout=subprocess.DEVNULL).returncode == 0:
-            return [Path(""), filename]
+    if _find_file(current_path / '..' / path, filename):
+        return _find_file(current_path / '..' / path, filename)
+
+    # Find binary in $PATH
+    if shutil.which(filename):
+        return [Path(""), Path(shutil.which(filename)).name]
+
+    # Find file in $PATH
+    if filename and subprocess.run('command -v ' + filename, shell=True, stdout=subprocess.DEVNULL).returncode == 0:
+        return [Path(""), filename]
 
     # Couldn't find file
     return [None, None]
+
+
+def _find_file(path="", filename=""):
+    """Looks both for file and for Windows users file.exe"""
+
+    if (Path(path) / Path(filename + '.exe')).exists():
+        return [Path(path), filename + '.exe']
+    if (Path(path) / filename).exists():
+        return [Path(path), filename]

--- a/bin/common.py
+++ b/bin/common.py
@@ -25,15 +25,20 @@ def find_path(path="", filename=""):
         return [Path(path), filename + '.exe']
     elif os.path.exists(Path(path) / filename):
         return [Path(path), filename]
+
     # Search one directory back
     elif os.path.exists(Path('..') / path / Path(filename + '.exe')):
         return [Path('..') / path, filename + '.exe']
     elif os.path.exists(Path('..') / path / filename):
         return [Path('..') / path, filename]
+
     # Search for program in $PATH
-    elif filename and subprocess.run('command -v ' + filename + '.exe', shell=True).returncode == 0:
-        return [Path(""), filename + '.exe']
-    elif filename and subprocess.run('command -v ' + filename, shell=True).returncode == 0:
-        return [Path(""), filename]
+    elif filename:
+        if subprocess.run('command -v ' + filename + '.exe', shell=True, stdout=subprocess.DEVNULL).returncode == 0:
+            return [Path(""), filename + '.exe']
+        elif subprocess.run('command -v ' + filename, shell=True, stdout=subprocess.DEVNULL).returncode == 0:
+            return [Path(""), filename]
+
     else:
+        # Couldn't find file
         return [None, None]

--- a/bin/common.py
+++ b/bin/common.py
@@ -14,28 +14,26 @@ from pathlib import Path
 import subprocess
 
 
-def find_path(path, filename=""):
-    """Looks for file in specified path. If not found, checks system path. Returns path if file is found."""
-    if filename == "":
-        filename = path
+def find_path(path="", filename=""):
+    """Looks for file in specified path. If not found, checks system path."""
 
-    if os.path.exists(Path.joinpath(Path('..'), path, filename + '.exe')):
-        return Path.joinpath(Path('..'), path, filename + '.exe')
-    elif os.path.exists(Path.joinpath(Path('..'), path, filename + '.jar')):
-        return Path.joinpath(Path('..'), path, filename + '.jar')
-    elif os.path.exists(Path.joinpath(Path('..'), path, filename)):
-        return Path.joinpath(Path('..'), path, filename)
-    elif os.path.exists(Path.joinpath(Path(path), filename + '.exe')):
-        return Path.joinpath(Path(path), filename + '.exe')
-    elif os.path.exists(Path.joinpath(Path(path), filename + '.jar')):
-        return Path.joinpath(Path(path), filename + '.jar')
-    elif os.path.exists(Path.joinpath(Path(path), filename)):
-        return Path.joinpath(Path(path), filename)
-    elif subprocess.run('command -v ' + filename + '.exe', shell=True).returncode == 0:
-        return subprocess.check_output('command -v ' + filename + '.exe', shell=True).strip().decode('utf-8')
-    elif subprocess.run('command -v ' + filename + '.exe', shell=True).returncode == 0:
-        return subprocess.check_output('command -v ' + filename + '.exe', shell=True).strip().decode('utf-8')
-    elif subprocess.run('command -v ' + filename, shell=True).returncode == 0:
-        return subprocess.check_output('command -v ' + filename, shell=True).strip().decode('utf-8')
+    # Converts abs path to relative path, ensuring searching one directory back works
+    path = os.path.relpath(Path(path))
+
+    # Search in specified path
+    if os.path.exists(Path(path) / Path(filename + '.exe')):
+        return [Path(path), filename + '.exe']
+    elif os.path.exists(Path(path) / filename):
+        return [Path(path), filename]
+    # Search one directory back
+    elif os.path.exists(Path('..') / path / Path(filename + '.exe')):
+        return [Path('..') / path, filename + '.exe']
+    elif os.path.exists(Path('..') / path / filename):
+        return [Path('..') / path, filename]
+    # Search for program in $PATH
+    elif filename and subprocess.run('command -v ' + filename + '.exe', shell=True).returncode == 0:
+        return [Path(""), filename + '.exe']
+    elif filename and subprocess.run('command -v ' + filename, shell=True).returncode == 0:
+        return [Path(""), filename]
     else:
-        return None
+        return [None, None]

--- a/bin/common.py
+++ b/bin/common.py
@@ -16,22 +16,23 @@ import subprocess
 
 def find_path(path="", filename=""):
     """Looks for file in specified path. If not found, checks system path."""
-
-    # Converts abs path to relative path, ensuring searching one directory back works
-    path = os.path.relpath(Path(path))
+    current_path = Path(__file__).parent  # common.py's path
 
     # Search in specified path
     if os.path.exists(Path(path) / Path(filename + '.exe')):
         return [Path(path), filename + '.exe']
     elif os.path.exists(Path(path) / filename):
         return [Path(path), filename]
-
-    # Search one directory back
-    elif os.path.exists(Path('..') / path / Path(filename + '.exe')):
-        return [Path('..') / path, filename + '.exe']
-    elif os.path.exists(Path('..') / path / filename):
-        return [Path('..') / path, filename]
-
+    # Search in common.py's path (usually bin folder)
+    if os.path.exists(current_path / path / Path(filename + '.exe')):
+        return [current_path / path, filename + '.exe']
+    elif os.path.exists(current_path / path / filename):
+        return [current_path / path, filename]
+    # Search one directory back (usually video2x folder)
+    elif os.path.exists(current_path / '..' / path / Path(filename + '.exe')):
+        return [current_path / '..' / path, filename + '.exe']
+    elif os.path.exists(current_path / '..' / path / filename):
+        return [current_path / '..' / path, filename]
     # Search for program in $PATH
     elif filename:
         if subprocess.run('command -v ' + filename + '.exe', shell=True, stdout=subprocess.DEVNULL).returncode == 0:
@@ -39,6 +40,5 @@ def find_path(path="", filename=""):
         elif subprocess.run('command -v ' + filename, shell=True, stdout=subprocess.DEVNULL).returncode == 0:
             return [Path(""), filename]
 
-    else:
-        # Couldn't find file
-        return [None, None]
+    # Couldn't find file
+    return [None, None]

--- a/bin/common.py
+++ b/bin/common.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Name: Video2X Common Code
+Author: ddouglas87
+Date Created: Sept 15, 2019
+Last Modified: Sept 15, 2019
+
+Description: This class contains helper functions.
+"""
+
+import os
+from pathlib import Path
+import subprocess
+
+
+def find_path(path, filename=""):
+    """Looks for file in specified path. If not found, checks system path. Returns path if file is found."""
+    if filename == "":
+        filename = path
+
+    if os.path.exists(Path.joinpath(Path('..'), path, filename + '.exe')):
+        return Path.joinpath(Path('..'), path, filename + '.exe')
+    elif os.path.exists(Path.joinpath(Path('..'), path, filename + '.jar')):
+        return Path.joinpath(Path('..'), path, filename + '.jar')
+    elif os.path.exists(Path.joinpath(Path('..'), path, filename)):
+        return Path.joinpath(Path('..'), path, filename)
+    elif os.path.exists(Path.joinpath(Path(path), filename + '.exe')):
+        return Path.joinpath(Path(path), filename + '.exe')
+    elif os.path.exists(Path.joinpath(Path(path), filename + '.jar')):
+        return Path.joinpath(Path(path), filename + '.jar')
+    elif os.path.exists(Path.joinpath(Path(path), filename)):
+        return Path.joinpath(Path(path), filename)
+    elif subprocess.run('command -v ' + filename + '.exe', shell=True).returncode == 0:
+        return subprocess.check_output('command -v ' + filename + '.exe', shell=True).strip().decode('utf-8')
+    elif subprocess.run('command -v ' + filename + '.exe', shell=True).returncode == 0:
+        return subprocess.check_output('command -v ' + filename + '.exe', shell=True).strip().decode('utf-8')
+    elif subprocess.run('command -v ' + filename, shell=True).returncode == 0:
+        return subprocess.check_output('command -v ' + filename, shell=True).strip().decode('utf-8')
+    else:
+        return None

--- a/bin/ffmpeg.py
+++ b/bin/ffmpeg.py
@@ -67,7 +67,7 @@ class Ffmpeg:
                 pass
 
         # print pixel formats for debugging
-        Avalon.debug_info(pixel_formats)
+        Avalon.debug_info(str(pixel_formats))
 
         return pixel_formats
 

--- a/bin/ffmpeg.py
+++ b/bin/ffmpeg.py
@@ -17,7 +17,7 @@ import subprocess
 from avalon_framework import Avalon
 
 
-class FFmpeg:
+class Ffmpeg:
     """This class communicates with FFmpeg
 
     This class deals with FFmpeg. It handles extracting
@@ -28,6 +28,8 @@ class FFmpeg:
     def __init__(self, settings, image_format):
         self.settings = settings
         self.image_format = image_format
+        self.ffmpeg_binary_path = self.settings['path'] / self.settings['ffmpeg_binary']
+        self.ffprobe_binary_path = self.settings['path'] / self.settings['ffprobe_binary']
 
     def get_pixel_formats(self):
         """ Get a dictionary of supported pixel formats
@@ -39,7 +41,7 @@ class FFmpeg:
             dictionary -- JSON dict of all pixel formats to bit depth
         """
         execute = [
-            self.settings['path'] / self.settings['ffprobe_binary'],
+            self.ffprobe_binary_path,
             '-v',
             'quiet',
             '-pix_fmts'
@@ -81,7 +83,7 @@ class FFmpeg:
         # this execution command needs to be hard-coded
         # since video2x only strictly recignizes this one format
         execute = [
-            self.settings['path'] / self.settings['ffprobe_binary'],
+            self.ffprobe_binary_path,
             '-v',
             'quiet',
             '-print_format',
@@ -109,7 +111,7 @@ class FFmpeg:
             extracted_frames {string} -- video output directory
         """
         execute = [
-            self.settings['path'] / self.settings['ffmpeg_binary'],
+            self.ffmpeg_binary_path,
         ]
 
         execute.extend(self._read_configuration(phase='video_to_frames'))
@@ -138,7 +140,7 @@ class FFmpeg:
             upscaled_frames {string} -- source images directory
         """
         execute = [
-            self.settings['path'] / self.settings['ffmpeg_binary'],
+            self.ffmpeg_binary_path,
             '-r',
             framerate,
             '-s',

--- a/bin/ffmpeg.py
+++ b/bin/ffmpeg.py
@@ -39,7 +39,7 @@ class FFmpeg:
             dictionary -- JSON dict of all pixel formats to bit depth
         """
         execute = [
-            self.settings['path'] / 'ffprobe',
+            self.settings['path'] / self.settings['ffprobe_binary'],
             '-v',
             'quiet',
             '-pix_fmts'
@@ -81,7 +81,7 @@ class FFmpeg:
         # this execution command needs to be hard-coded
         # since video2x only strictly recignizes this one format
         execute = [
-            self.settings['path'] / 'ffprobe',
+            self.settings['path'] / self.settings['ffprobe_binary'],
             '-v',
             'quiet',
             '-print_format',
@@ -109,7 +109,7 @@ class FFmpeg:
             extracted_frames {string} -- video output directory
         """
         execute = [
-            self.settings['path'] / 'ffmpeg',
+            self.settings['path'] / self.settings['ffmpeg_binary'],
         ]
 
         execute.extend(self._read_configuration(phase='video_to_frames'))
@@ -138,7 +138,7 @@ class FFmpeg:
             upscaled_frames {string} -- source images directory
         """
         execute = [
-            self.settings['path'] / 'ffmpeg',
+            self.settings['path'] / self.settings['ffmpeg_binary'],
             '-r',
             framerate,
             '-s',
@@ -185,7 +185,7 @@ class FFmpeg:
             upscaled_frames {string} -- directory containing upscaled frames
         """
         execute = [
-            self.settings['path'] / 'ffmpeg',
+            self.settings['path'] / self.settings['ffmpeg_binary'],
         ]
 
         execute.extend(self._read_configuration(phase='migrating_tracks'))

--- a/bin/ffmpeg.py
+++ b/bin/ffmpeg.py
@@ -284,4 +284,4 @@ class Ffmpeg:
 
         Avalon.debug_info(f'Executing: {execute}')
 
-        return subprocess.run(execute, shell=True, check=True).returncode
+        return subprocess.run(execute, check=True).returncode

--- a/bin/ffmpeg.py
+++ b/bin/ffmpeg.py
@@ -9,9 +9,6 @@ Last Modified: August 15, 2019
 Description: This class handles all FFmpeg related operations.
 """
 
-# local imports
-import common
-
 # built-in imports
 import json
 import subprocess
@@ -32,10 +29,6 @@ class FFmpeg:
         self.settings = settings
         self.image_format = image_format
 
-        self.ffmpeg_path = common.find_path(self.settings['path'], 'ffmpeg')
-        self.ffprobe_path = common.find_path(self.settings['path'], 'ffprobe')
-        self.pixel_format = None
-
     def get_pixel_formats(self):
         """ Get a dictionary of supported pixel formats
 
@@ -46,7 +39,7 @@ class FFmpeg:
             dictionary -- JSON dict of all pixel formats to bit depth
         """
         execute = [
-            self.ffprobe_path,
+            self.settings['path'] / 'ffprobe',
             '-v',
             'quiet',
             '-pix_fmts'
@@ -88,7 +81,7 @@ class FFmpeg:
         # this execution command needs to be hard-coded
         # since video2x only strictly recignizes this one format
         execute = [
-            self.ffprobe_path,
+            self.settings['path'] / 'ffprobe',
             '-v',
             'quiet',
             '-print_format',
@@ -116,7 +109,7 @@ class FFmpeg:
             extracted_frames {string} -- video output directory
         """
         execute = [
-            self.ffmpeg_path
+            self.settings['path'] / 'ffmpeg',
         ]
 
         execute.extend(self._read_configuration(phase='video_to_frames'))
@@ -145,9 +138,9 @@ class FFmpeg:
             upscaled_frames {string} -- source images directory
         """
         execute = [
-            self.ffmpeg_path,
+            self.settings['path'] / 'ffmpeg',
             '-r',
-            str(framerate),
+            framerate,
             '-s',
             resolution
         ]
@@ -192,7 +185,7 @@ class FFmpeg:
             upscaled_frames {string} -- directory containing upscaled frames
         """
         execute = [
-            self.ffmpeg_path
+            self.settings['path'] / 'ffmpeg',
         ]
 
         execute.extend(self._read_configuration(phase='migrating_tracks'))

--- a/bin/upscaler.py
+++ b/bin/upscaler.py
@@ -22,7 +22,6 @@ from image_cleaner import ImageCleaner
 from waifu2x_caffe import Waifu2xCaffe
 from waifu2x_converter import Waifu2xConverter
 from waifu2x_ncnn_vulkan import Waifu2xNcnnVulkan
-import common
 
 # built-in imports
 from fractions import Fraction
@@ -35,7 +34,6 @@ import tempfile
 import threading
 import time
 import traceback
-import sys
 
 # third-party imports
 from avalon_framework import Avalon
@@ -70,23 +68,6 @@ class Upscaler:
         self.video2x_cache_directory = pathlib.Path(tempfile.gettempdir()) / 'video2x'
         self.image_format = 'png'
         self.preserve_frames = False
-
-        # Search for valid waifu2x binary path
-        if 'win_binary' in self.waifu2x_settings and sys.platform == 'win32':
-            path = common.find_path(self.waifu2x_settings['path'], self.waifu2x_settings['win_binary'])
-        else:
-            path = common.find_path(self.waifu2x_settings['path'], self.waifu2x_settings['binary'])
-        self.waifu2x_settings['path'] = path[0]
-        self.waifu2x_settings['binary'] = path[1]
-
-        # Search for valid java binary path
-        if 'java_path' in self.waifu2x_settings:
-            path = common.find_path(self.waifu2x_settings['java_path'], 'java')
-            self.waifu2x_settings['java_path'] = path[0]
-            self.waifu2x_settings['java_binary'] = path[1]
-
-        # Search for valid ffmpeg path
-        self.ffmpeg_settings['path'] = common.find_path(self.ffmpeg_settings['path'], 'ffmpeg')[0]
 
     def create_temp_directories(self):
         """create temporary directory

--- a/bin/upscaler.py
+++ b/bin/upscaler.py
@@ -17,7 +17,7 @@ Licensed under the GNU General Public License Version 3 (GNU GPL v3),
 # local imports
 from anime4k import Anime4k
 from exceptions import *
-from ffmpeg import Ffmpeg
+from ffmpeg import FFmpeg
 from image_cleaner import ImageCleaner
 from waifu2x_caffe import Waifu2xCaffe
 from waifu2x_converter import Waifu2xConverter
@@ -308,7 +308,7 @@ class Upscaler:
         self.output_video = self.output_video.absolute()
 
         # initialize objects for ffmpeg and waifu2x-caffe
-        fm = Ffmpeg(self.ffmpeg_settings, self.image_format)
+        fm = FFmpeg(self.ffmpeg_settings, self.image_format)
 
         # extract frames from video
         fm.extract_frames(self.input_video, self.extracted_frames)

--- a/bin/upscaler.py
+++ b/bin/upscaler.py
@@ -64,6 +64,7 @@ class Upscaler:
         self.scale_width = None
         self.scale_height = None
         self.scale_ratio = None
+        self.model_dir = None
         self.threads = 5
         self.video2x_cache_directory = pathlib.Path(tempfile.gettempdir()) / 'video2x'
         self.image_format = 'png'
@@ -164,7 +165,7 @@ class Upscaler:
         # it's easier to do multi-threading with waifu2x_converter
         # the number of threads can be passed directly to waifu2x_converter
         if self.waifu2x_driver == 'waifu2x_converter':
-            w2 = Waifu2xConverter(self.waifu2x_settings)
+            w2 = Waifu2xConverter(self.waifu2x_settings, self.model_dir)
 
             progress_bar = threading.Thread(target=self._progress_bar, args=([self.extracted_frames],))
             progress_bar.start()
@@ -221,7 +222,7 @@ class Upscaler:
 
                 # create a separate w2 instance for each thread
                 if self.waifu2x_driver == 'waifu2x_caffe':
-                    w2 = Waifu2xCaffe(copy.deepcopy(self.waifu2x_settings), self.method, self.bit_depth)
+                    w2 = Waifu2xCaffe(copy.deepcopy(self.waifu2x_settings), self.method, self.model_dir, self.bit_depth)
                     if self.scale_ratio:
                         thread = threading.Thread(target=w2.upscale,
                                                   args=(thread_info[0],
@@ -243,7 +244,7 @@ class Upscaler:
 
                 # if the driver being used is waifu2x_ncnn_vulkan
                 elif self.waifu2x_driver == 'waifu2x_ncnn_vulkan':
-                    w2 = Waifu2xNcnnVulkan(copy.deepcopy(self.waifu2x_settings))
+                    w2 = Waifu2xNcnnVulkan(copy.deepcopy(self.waifu2x_settings), self.model_dir)
                     thread = threading.Thread(target=w2.upscale,
                                               args=(thread_info[0],
                                                     self.upscaled_frames,

--- a/bin/upscaler.py
+++ b/bin/upscaler.py
@@ -17,7 +17,7 @@ Licensed under the GNU General Public License Version 3 (GNU GPL v3),
 # local imports
 from anime4k import Anime4k
 from exceptions import *
-from ffmpeg import FFmpeg
+from ffmpeg import Ffmpeg
 from image_cleaner import ImageCleaner
 from waifu2x_caffe import Waifu2xCaffe
 from waifu2x_converter import Waifu2xConverter
@@ -308,7 +308,7 @@ class Upscaler:
         self.output_video = self.output_video.absolute()
 
         # initialize objects for ffmpeg and waifu2x-caffe
-        fm = FFmpeg(self.ffmpeg_settings, self.image_format)
+        fm = Ffmpeg(self.ffmpeg_settings, self.image_format)
 
         # extract frames from video
         fm.extract_frames(self.input_video, self.extracted_frames)

--- a/bin/video2x.json
+++ b/bin/video2x.json
@@ -83,9 +83,11 @@
     "migrating_tracks": {
       "output_options": {
         "-map": [
-          "0:v:0?",
-          "1?",
-          "-1:v?"
+          "0:v?",
+          "1:a?",
+          "1:s?",
+          "1:d?",
+          "1:t?"
         ],
         "-c": "copy",
         "-pix_fmt": null

--- a/bin/video2x.json
+++ b/bin/video2x.json
@@ -1,6 +1,7 @@
 {
   "waifu2x_caffe": {
-    "waifu2x_caffe_path": "C:\\Users\\K4YT3X\\AppData\\Local\\video2x\\waifu2x-caffe\\waifu2x-caffe-cui.exe",
+    "path": "waifu2x-caffe",
+    "win_binary": "waifu2x-caffe-cui.exe",
     "input_extention_list": null,
     "output_extention": null,
     "mode": "noise_scale",
@@ -22,7 +23,7 @@
     "crop_h": null
   },
   "waifu2x_converter": {
-    "waifu2x_converter_path": "C:\\Users\\K4YT3X\\AppData\\Local\\video2x\\waifu2x-converter-cpp",
+    "path": "waifu2x-converter-cpp",
     "output-format": null,
     "png-compression": null,
     "image-quality": null,
@@ -40,7 +41,7 @@
     "input": null
   },
   "waifu2x_ncnn_vulkan": {
-    "waifu2x_ncnn_vulkan_path": "C:\\Users\\K4YT3X\\AppData\\Local\\video2x\\waifu2x-ncnn-vulkan\\waifu2x-ncnn-vulkan.exe",
+    "path": "waifu2x-ncnn-vulkan",
     "v": null,
     "i": null,
     "o": null,
@@ -52,11 +53,11 @@
     "j": "1:2:2"
   },
   "anime4k": {
-    "anime4k_path": "C:\\Users\\K4YT3X\\AppData\\Local\\video2x\\anime4k\\Anime4K.jar",
+    "path": "anime4k",
     "java_path": "C:\\Program Files\\Java\\jdk-12.0.2\\bin\\java.exe"
   },
   "ffmpeg": {
-    "ffmpeg_path": "C:\\Users\\K4YT3X\\AppData\\Local\\video2x\\ffmpeg-latest-win64-static\\bin",
+    "path": "ffmpeg-latest-win64-static\\bin",
     "video_to_frames": {
       "output_options": {
         "-qscale:v": null,
@@ -99,6 +100,6 @@
   "video2x": {
     "video2x_cache_directory": null,
     "image_format": "png",
-    "preserve_frames": false
+    "preserve_frames": true
   }
 }

--- a/bin/video2x.json
+++ b/bin/video2x.json
@@ -1,6 +1,7 @@
 {
   "waifu2x_caffe": {
     "path": "waifu2x-caffe",
+    "binary": "waifu2x-caffe",
     "win_binary": "waifu2x-caffe-cui.exe",
     "input_extention_list": null,
     "output_extention": null,
@@ -18,12 +19,13 @@
     "tta": 0,
     "input_path": null,
     "output_path": null,
-    "model_dir": null,
+    "model_dir": "models/cunet",
     "crop_w": null,
     "crop_h": null
   },
   "waifu2x_converter": {
     "path": "waifu2x-converter-cpp",
+    "binary": "waifu2x-converter-cpp",
     "output-format": null,
     "png-compression": null,
     "image-quality": null,
@@ -32,29 +34,32 @@
     "force-OpenCL": null,
     "processor": null,
     "jobs": null,
-    "model-dir": null,
+    "model-dir": "models_rgb",
     "scale-ratio": null,
     "noise-level": 3,
     "mode": "noise-scale",
-    "silent": true,
+    "log-level": 0,
+    "auto-naming": 0,
     "output": null,
     "input": null
   },
   "waifu2x_ncnn_vulkan": {
     "path": "waifu2x-ncnn-vulkan",
+    "binary": "waifu2x-ncnn-vulkan",
     "v": null,
     "i": null,
     "o": null,
-    "n": 2,
+    "n": 3,
     "s": 2,
-    "t": 400,
+    "t": 128,
     "m": "models-cunet",
     "g": 0,
     "j": "1:2:2"
   },
   "anime4k": {
     "path": "anime4k",
-    "java_path": "C:\\Program Files\\Java\\jdk-12.0.2\\bin\\java.exe"
+    "binary": "Anime4K.jar",
+    "java_path": "C:\\Program Files\\Java\\jdk-12.0.2\\bin"
   },
   "ffmpeg": {
     "path": "ffmpeg-latest-win64-static\\bin",

--- a/bin/video2x.json
+++ b/bin/video2x.json
@@ -105,6 +105,6 @@
   "video2x": {
     "video2x_cache_directory": null,
     "image_format": "png",
-    "preserve_frames": true
+    "preserve_frames": false
   }
 }

--- a/bin/video2x.py
+++ b/bin/video2x.py
@@ -46,6 +46,7 @@ smooth and edges sharp.
 from exceptions import *
 from upscaler import AVAILABLE_DRIVERS
 from upscaler import Upscaler
+import common
 
 # built-in imports
 import argparse
@@ -298,33 +299,14 @@ if args.driver == 'anime4k' and args.threads <= 1:
 
 # read configurations from JSON
 config = read_config(args.config)
-config = absolutify_paths(config)
+# config = absolutify_paths(config)
 
 # load waifu2x configuration
-if args.driver == 'waifu2x_caffe':
-    waifu2x_settings = config['waifu2x_caffe']
-    if not pathlib.Path(waifu2x_settings['waifu2x_caffe_path']).is_file():
-        Avalon.error('Specified waifu2x-caffe directory doesn\'t exist')
-        Avalon.error('Please check the configuration file settings')
-        raise FileNotFoundError(waifu2x_settings['waifu2x_caffe_path'])
-elif args.driver == 'waifu2x_converter':
-    waifu2x_settings = config['waifu2x_converter']
-    if not pathlib.Path(waifu2x_settings['waifu2x_converter_path']).is_dir():
-        Avalon.error('Specified waifu2x-converter-cpp directory doesn\'t exist')
-        Avalon.error('Please check the configuration file settings')
-        raise FileNotFoundError(waifu2x_settings['waifu2x_converter_path'])
-elif args.driver == 'waifu2x_ncnn_vulkan':
-    waifu2x_settings = config['waifu2x_ncnn_vulkan']
-    if not pathlib.Path(waifu2x_settings['waifu2x_ncnn_vulkan_path']).is_file():
-        Avalon.error('Specified waifu2x_ncnn_vulkan directory doesn\'t exist')
-        Avalon.error('Please check the configuration file settings')
-        raise FileNotFoundError(waifu2x_settings['waifu2x_ncnn_vulkan_path'])
-elif args.driver == 'anime4k':
-    waifu2x_settings = config['anime4k']
-    if not pathlib.Path(waifu2x_settings['anime4k_path']).is_file():
-        Avalon.error('Specified anime4k directory doesn\'t exist')
-        Avalon.error('Please check the configuration file settings')
-        raise FileNotFoundError(waifu2x_settings['anime4k_path'])
+waifu2x_settings = config[args.driver]
+if common.find_path(waifu2x_settings['path']) is None:
+    Avalon.error("Specified" + args.driver + "directory doesn't exist")
+    Avalon.error("Please check the configuration file settings")
+    raise FileNotFoundError(waifu2x_settings['path'])
 
 # read FFmpeg configuration
 ffmpeg_settings = config['ffmpeg']

--- a/bin/video2x.py
+++ b/bin/video2x.py
@@ -46,7 +46,6 @@ smooth and edges sharp.
 from exceptions import *
 from upscaler import AVAILABLE_DRIVERS
 from upscaler import Upscaler
-import common
 
 # built-in imports
 import argparse
@@ -197,48 +196,6 @@ def read_config(config_file):
         return config
 
 
-def absolutify_paths(config):
-    """ Check to see if paths to binaries are absolute
-
-    This function checks if paths to binary files are absolute.
-    If not, then absolutify the path.
-
-    Arguments:
-        config {dict} -- configuration file dictionary
-
-    Returns:
-        dict -- configuration file dictionary
-    """
-    current_directory = pathlib.Path(sys.argv[0]).parent.absolute()
-
-    # check waifu2x-caffe path
-    if not re.match('^[a-z]:', config['waifu2x_caffe']['waifu2x_caffe_path'], re.IGNORECASE):
-        config['waifu2x_caffe']['waifu2x_caffe_path'] = current_directory / config['waifu2x_caffe']['waifu2x_caffe_path']
-
-    # check waifu2x-converter-cpp path
-    if not re.match('^[a-z]:', config['waifu2x_converter']['waifu2x_converter_path'], re.IGNORECASE):
-        config['waifu2x_converter']['waifu2x_converter_path'] = current_directory / config['waifu2x_converter']['waifu2x_converter_path']
-
-    # check waifu2x_ncnn_vulkan path
-    if not re.match('^[a-z]:', config['waifu2x_ncnn_vulkan']['waifu2x_ncnn_vulkan_path'], re.IGNORECASE):
-        config['waifu2x_ncnn_vulkan']['waifu2x_ncnn_vulkan_path'] = current_directory / config['waifu2x_ncnn_vulkan']['waifu2x_ncnn_vulkan_path']
-
-    # check anime4k path
-    if not re.match('^[a-z]:', config['anime4k']['anime4k_path'], re.IGNORECASE):
-        config['anime4k']['anime4k_path'] = current_directory / config['anime4k']['anime4k_path']
-
-    # check ffmpeg path
-    if not re.match('^[a-z]:', config['ffmpeg']['ffmpeg_path'], re.IGNORECASE):
-        config['ffmpeg']['ffmpeg_path'] = current_directory / config['ffmpeg']['ffmpeg_path']
-
-    # check video2x cache path
-    if config['video2x']['video2x_cache_directory']:
-        if not re.match('^[a-z]:', config['video2x']['video2x_cache_directory'], re.IGNORECASE):
-            config['video2x']['video2x_cache_directory'] = current_directory / config['video2x']['video2x_cache_directory']
-
-    return config
-
-
 # /////////////////// Execution /////////////////// #
 
 # this is not a library
@@ -299,14 +256,9 @@ if args.driver == 'anime4k' and args.threads <= 1:
 
 # read configurations from JSON
 config = read_config(args.config)
-# config = absolutify_paths(config)
 
 # load waifu2x configuration
 waifu2x_settings = config[args.driver]
-if common.find_path(waifu2x_settings['path']) is None:
-    Avalon.error("Specified" + args.driver + "directory doesn't exist")
-    Avalon.error("Please check the configuration file settings")
-    raise FileNotFoundError(waifu2x_settings['path'])
 
 # read FFmpeg configuration
 ffmpeg_settings = config['ffmpeg']

--- a/bin/video2x.py
+++ b/bin/video2x.py
@@ -46,6 +46,7 @@ smooth and edges sharp.
 from exceptions import *
 from upscaler import AVAILABLE_DRIVERS
 from upscaler import Upscaler
+import common
 
 # built-in imports
 import argparse
@@ -58,6 +59,7 @@ import sys
 import tempfile
 import time
 import traceback
+import sys
 
 # third-party imports
 from avalon_framework import Avalon
@@ -260,8 +262,35 @@ config = read_config(args.config)
 # load waifu2x configuration
 waifu2x_settings = config[args.driver]
 
+# Search for valid java binary path
+if args.driver == 'anime4k':
+    path = common.find_path(waifu2x_settings['java_path'], 'java')
+    waifu2x_settings['java_path'] = path[0]
+    waifu2x_settings['java_binary'] = path[1]
+
+    if waifu2x_settings['java_path'] is None and waifu2x_settings['java_binary'] is None:
+        raise FileNotFoundError('java')
+
+# Search for valid waifu2x binary path
+if 'win_binary' in waifu2x_settings and sys.platform == 'win32':
+    path = common.find_path(waifu2x_settings['path'], waifu2x_settings['win_binary'])
+else:
+    path = common.find_path(waifu2x_settings['path'], waifu2x_settings['binary'])
+waifu2x_settings['path'] = path[0]
+waifu2x_settings['binary'] = path[1]
+
+if waifu2x_settings['path'] is None and waifu2x_settings['binary'] is None:
+    raise FileNotFoundError(args.driver)
+
 # read FFmpeg configuration
 ffmpeg_settings = config['ffmpeg']
+
+# Search for valid ffmpeg path
+ffmpeg_path = common.find_path(ffmpeg_settings['path'], 'ffmpeg')
+ffprobe_path = common.find_path(ffmpeg_settings['path'], 'ffprobe')
+ffmpeg_settings['path'] = ffmpeg_path[0]
+ffmpeg_settings['ffmpeg_binary'] = ffmpeg_path[1]
+ffmpeg_settings['ffprobe_binary'] = ffprobe_path[1]
 
 # load video2x settings
 image_format = config['video2x']['image_format'].lower()

--- a/bin/video2x.py
+++ b/bin/video2x.py
@@ -59,7 +59,7 @@ import sys
 import tempfile
 import time
 import traceback
-import sys
+from pathlib import Path
 
 # third-party imports
 from avalon_framework import Avalon
@@ -265,22 +265,23 @@ waifu2x_settings = config[args.driver]
 # Search for valid java binary path
 if args.driver == 'anime4k':
     path = common.find_path(waifu2x_settings['java_path'], 'java')
+    if path[0] is None and path[1] is None:
+        raise FileNotFoundError(Path(waifu2x_settings['java_path']).absolute() / 'java')
+
     waifu2x_settings['java_path'] = path[0]
     waifu2x_settings['java_binary'] = path[1]
 
-    if waifu2x_settings['java_path'] is None and waifu2x_settings['java_binary'] is None:
-        raise FileNotFoundError('java')
 
 # Search for valid waifu2x binary path
 if 'win_binary' in waifu2x_settings and sys.platform == 'win32':
-    path = common.find_path(waifu2x_settings['path'], waifu2x_settings['win_binary'])
-else:
-    path = common.find_path(waifu2x_settings['path'], waifu2x_settings['binary'])
+    waifu2x_settings['binary'] = waifu2x_settings['win_binary']
+
+path = common.find_path(waifu2x_settings['path'], waifu2x_settings['binary'])
+if path[0] is None and path[1] is None:
+    raise FileNotFoundError(Path(waifu2x_settings['path']).absolute() / waifu2x_settings['binary'])
+
 waifu2x_settings['path'] = path[0]
 waifu2x_settings['binary'] = path[1]
-
-if waifu2x_settings['path'] is None and waifu2x_settings['binary'] is None:
-    raise FileNotFoundError(args.driver)
 
 # read FFmpeg configuration
 ffmpeg_settings = config['ffmpeg']

--- a/bin/video2x.py
+++ b/bin/video2x.py
@@ -243,10 +243,10 @@ if args.driver in ['waifu2x_caffe', 'waifu2x_converter', 'waifu2x_ncnn_vulkan']:
 # anime4k runs significantly faster with more threads
 if args.driver == 'anime4k' and args.threads <= 1:
     Avalon.warning('Anime4K runs significantly faster with more threads')
-    if Avalon.ask('Use more threads of Anime4K?', True):
+    if Avalon.ask('Use more threads of Anime4K?', default=True, batch=args.batch):
         while True:
             try:
-                threads = Avalon.gets('Amount of threads to use [5]: ')
+                threads = Avalon.gets('Amount of threads to use [5]: ', default=5, batch=args.batch)
                 args.threads = int(threads)
                 break
             except ValueError:

--- a/bin/video2x_setup.py
+++ b/bin/video2x_setup.py
@@ -180,16 +180,16 @@ class Video2xSetup:
                 self.trash.append(waifu2x_ncnn_vulkan_zip)
 
         # extract and rename
-        waifu2x_ncnn_vulkan_directory = VIDEO2X_PATH / 'video2x' / 'waifu2x-ncnn-vulkan'
+        waifu2x_ncnn_vulkan_directory = VIDEO2X_PATH / 'waifu2x-ncnn-vulkan'
         with zipfile.ZipFile(waifu2x_ncnn_vulkan_zip) as zipf:
-            zipf.extractall(VIDEO2X_PATH / 'video2x')
+            zipf.extractall(VIDEO2X_PATH)
 
             # if directory already exists, remove it
             if waifu2x_ncnn_vulkan_directory.exists():
                 shutil.rmtree(waifu2x_ncnn_vulkan_directory)
 
             # rename the newly extracted directory
-            (VIDEO2X_PATH / 'video2x' / zipf.namelist()[0]).rename(waifu2x_ncnn_vulkan_directory)
+            (VIDEO2X_PATH / zipf.namelist()[0]).rename(waifu2x_ncnn_vulkan_directory)
 
     def _install_anime4k(self):
         """ Install Anime4K
@@ -217,7 +217,7 @@ class Video2xSetup:
 
         # extract and rename
         with zipfile.ZipFile(anime4k_zip) as zipf:
-            zipf.extractall(VIDEO2X_PATH / 'video2x' / 'anime4k')
+            zipf.extractall(VIDEO2X_PATH / 'anime4k')
 
 
 def download(url, save_path, chunk_size=4096):

--- a/bin/video2x_setup.py
+++ b/bin/video2x_setup.py
@@ -28,9 +28,7 @@ Installation Details:
 # built-in imports
 import argparse
 import contextlib
-import json
-import os
-import pathlib
+from pathlib import Path
 import re
 import shutil
 import subprocess
@@ -48,7 +46,7 @@ import zipfile
 VERSION = '1.5.0'
 
 # global static variables
-LOCALAPPDATA = pathlib.Path(os.getenv('localappdata'))
+VIDEO2X_PATH = Path(__file__).parent
 DRIVER_OPTIONS = ['all', 'waifu2x_caffe', 'waifu2x_converter', 'waifu2x_ncnn_vulkan', 'anime4k']
 
 
@@ -99,9 +97,6 @@ class Video2xSetup:
         elif self.driver == 'anime4k':
             self._install_anime4k()
 
-        print('\nGenerating Video2X configuration file')
-        self._generate_config()
-
         print('\nCleaning up temporary files')
         self._cleanup()
 
@@ -134,7 +129,7 @@ class Video2xSetup:
         self.trash.append(ffmpeg_zip)
 
         with zipfile.ZipFile(ffmpeg_zip) as zipf:
-            zipf.extractall(LOCALAPPDATA / 'video2x')
+            zipf.extractall(VIDEO2X_PATH)
 
     def _install_waifu2x_caffe(self):
         """ Install waifu2x_caffe
@@ -151,7 +146,7 @@ class Video2xSetup:
                 self.trash.append(waifu2x_caffe_zip)
 
         with zipfile.ZipFile(waifu2x_caffe_zip) as zipf:
-            zipf.extractall(LOCALAPPDATA / 'video2x')
+            zipf.extractall(VIDEO2X_PATH)
 
     def _install_waifu2x_converter_cpp(self):
         """ Install waifu2x_caffe
@@ -168,7 +163,7 @@ class Video2xSetup:
                 self.trash.append(waifu2x_converter_cpp_zip)
 
         with zipfile.ZipFile(waifu2x_converter_cpp_zip) as zipf:
-            zipf.extractall(LOCALAPPDATA / 'video2x' / 'waifu2x-converter-cpp')
+            zipf.extractall(VIDEO2X_PATH / 'waifu2x-converter-cpp')
 
     def _install_waifu2x_ncnn_vulkan(self):
         """ Install waifu2x-ncnn-vulkan
@@ -185,16 +180,16 @@ class Video2xSetup:
                 self.trash.append(waifu2x_ncnn_vulkan_zip)
 
         # extract and rename
-        waifu2x_ncnn_vulkan_directory = LOCALAPPDATA / 'video2x' / 'waifu2x-ncnn-vulkan'
+        waifu2x_ncnn_vulkan_directory = VIDEO2X_PATH / 'video2x' / 'waifu2x-ncnn-vulkan'
         with zipfile.ZipFile(waifu2x_ncnn_vulkan_zip) as zipf:
-            zipf.extractall(LOCALAPPDATA / 'video2x')
+            zipf.extractall(VIDEO2X_PATH / 'video2x')
 
             # if directory already exists, remove it
             if waifu2x_ncnn_vulkan_directory.exists():
                 shutil.rmtree(waifu2x_ncnn_vulkan_directory)
 
             # rename the newly extracted directory
-            (LOCALAPPDATA / 'video2x' / zipf.namelist()[0]).rename(waifu2x_ncnn_vulkan_directory)
+            (VIDEO2X_PATH / 'video2x' / zipf.namelist()[0]).rename(waifu2x_ncnn_vulkan_directory)
 
     def _install_anime4k(self):
         """ Install Anime4K
@@ -222,39 +217,7 @@ class Video2xSetup:
 
         # extract and rename
         with zipfile.ZipFile(anime4k_zip) as zipf:
-            zipf.extractall(LOCALAPPDATA / 'video2x' / 'anime4k')
-
-    def _generate_config(self):
-        """ Generate video2x config
-        """
-        # Open current video2x.json file as template
-        with open('video2x.json', 'r') as template:
-            template_dict = json.load(template)
-            template.close()
-
-        # configure only the specified drivers
-        if self.driver == 'all':
-            template_dict['waifu2x_caffe']['waifu2x_caffe_path'] = str(LOCALAPPDATA / 'video2x' / 'waifu2x-caffe' / 'waifu2x-caffe-cui.exe')
-            template_dict['waifu2x_converter']['waifu2x_converter_path'] = str(LOCALAPPDATA / 'video2x' / 'waifu2x-converter-cpp')
-            template_dict['waifu2x_ncnn_vulkan']['waifu2x_ncnn_vulkan_path'] = str(LOCALAPPDATA / 'video2x' / 'waifu2x-ncnn-vulkan' / 'waifu2x-ncnn-vulkan.exe')
-            template_dict['anime4k']['anime4k_path'] = str(LOCALAPPDATA / 'video2x' / 'anime4k' / 'Anime4K.jar')
-        elif self.driver == 'waifu2x_caffe':
-            template_dict['waifu2x_caffe']['waifu2x_caffe_path'] = str(LOCALAPPDATA / 'video2x' / 'waifu2x-caffe' / 'waifu2x-caffe-cui.exe')
-        elif self.driver == 'waifu2x_converter':
-            template_dict['waifu2x_converter']['waifu2x_converter_path'] = str(LOCALAPPDATA / 'video2x' / 'waifu2x-converter-cpp')
-        elif self.driver == 'waifu2x_ncnn_vulkan':
-            template_dict['waifu2x_ncnn_vulkan']['waifu2x_ncnn_vulkan_path'] = str(LOCALAPPDATA / 'video2x' / 'waifu2x-ncnn-vulkan' / 'waifu2x-ncnn-vulkan.exe')
-        elif self.driver == 'anime4k':
-            template_dict['anime4k']['anime4k_path'] = str(LOCALAPPDATA / 'video2x' / 'anime4k' / 'Anime4K.jar')
-
-        template_dict['ffmpeg']['ffmpeg_path'] = str(LOCALAPPDATA / 'video2x' / 'ffmpeg-latest-win64-static' / 'bin')
-        template_dict['video2x']['video2x_cache_directory'] = None
-        template_dict['video2x']['preserve_frames'] = False
-
-        # Write configuration into file
-        with open('video2x.json', 'w') as config:
-            json.dump(template_dict, config, indent=2)
-            config.close()
+            zipf.extractall(VIDEO2X_PATH / 'video2x' / 'anime4k')
 
 
 def download(url, save_path, chunk_size=4096):

--- a/bin/waifu2x_caffe.py
+++ b/bin/waifu2x_caffe.py
@@ -30,7 +30,7 @@ class Waifu2xCaffe:
     the upscale function.
     """
 
-    def __init__(self, settings, process, bit_depth):
+    def __init__(self, settings, process, model_dir, bit_depth):
         self.settings = settings
         self.settings['process'] = process
         self.settings['output_depth'] = bit_depth
@@ -38,6 +38,9 @@ class Waifu2xCaffe:
         # arguments passed through command line overwrites config file values
         self.process = process
         self.print_lock = threading.Lock()
+
+        if model_dir:
+            self.settings['model_dir'] = model_dir
 
         # Searches for models directory
         if 'model_dir' in self.settings:

--- a/bin/waifu2x_caffe.py
+++ b/bin/waifu2x_caffe.py
@@ -85,7 +85,7 @@ class Waifu2xCaffe:
             execute = [self.settings['path'] / self.settings['binary']]
 
             for key, value in self.settings.items():
-                if key == 'path' or key == 'binary' or key == 'win_binary':
+                if key in ['path', 'binary', 'win_binary']:
                     continue
                 # is executable key or null or None means that leave this option out (keep default)
                 if value is None or value is False:

--- a/bin/waifu2x_caffe.py
+++ b/bin/waifu2x_caffe.py
@@ -10,9 +10,13 @@ Description: This class is a high-level wrapper
 for waifu2x-caffe.
 """
 
+# local imports
+import common
+
 # built-in imports
 import subprocess
 import threading
+import sys
 
 # third-party imports
 from avalon_framework import Avalon
@@ -27,11 +31,11 @@ class Waifu2xCaffe:
     the upscale function.
     """
 
-    def __init__(self, waifu2x_settings, process, model_dir, bit_depth):
-        self.waifu2x_settings = waifu2x_settings
-        self.waifu2x_settings['process'] = process
-        self.waifu2x_settings['model_dir'] = model_dir
-        self.waifu2x_settings['output_depth'] = bit_depth
+    def __init__(self, settings, process, model_dir, bit_depth):
+        self.settings = settings
+        self.settings['process'] = process
+        self.settings['model_dir'] = model_dir
+        self.settings['output_depth'] = bit_depth
 
         # arguments passed through command line overwrites config file values
         self.process = process
@@ -50,16 +54,16 @@ class Waifu2xCaffe:
 
         try:
             # overwrite config file settings
-            self.waifu2x_settings['input_path'] = input_directory
-            self.waifu2x_settings['output_path'] = output_directory
+            self.settings['input_path'] = input_directory
+            self.settings['output_path'] = output_directory
 
             if scale_ratio:
-                self.waifu2x_settings['scale_ratio'] = scale_ratio
+                self.settings['scale_ratio'] = scale_ratio
             elif scale_width and scale_height:
-                self.waifu2x_settings['scale_width'] = scale_width
-                self.waifu2x_settings['scale_height'] = scale_height
+                self.settings['scale_width'] = scale_width
+                self.settings['scale_height'] = scale_height
 
-            self.waifu2x_settings['output_extention'] = image_format
+            self.settings['output_extention'] = image_format
 
             # print thread start message
             self.print_lock.acquire()
@@ -68,14 +72,17 @@ class Waifu2xCaffe:
 
             # list to be executed
             # initialize the list with waifu2x binary path as the first element
-            execute = [str(self.waifu2x_settings['waifu2x_caffe_path'])]
+            if sys.platform == 'win32':
+                execute = [common.find_path(self.settings['path'], self.settings['win_binary'])]
+            else:
+                execute = [common.find_path(self.settings['path'])]
 
-            for key in self.waifu2x_settings.keys():
+            for key in self.settings.keys():
 
-                value = self.waifu2x_settings[key]
+                value = self.settings[key]
 
                 # is executable key or null or None means that leave this option out (keep default)
-                if key == 'waifu2x_caffe_path' or value is None or value is False:
+                if key == 'path' or key == 'win_binary' or value is None or value is False:
                     continue
                 else:
                     if len(key) == 1:

--- a/bin/waifu2x_converter.py
+++ b/bin/waifu2x_converter.py
@@ -10,6 +10,9 @@ Description: This class is a high-level wrapper
 for waifu2x-converter-cpp.
 """
 
+# local imports
+import common
+
 # built-in imports
 import pathlib
 import subprocess
@@ -28,9 +31,9 @@ class Waifu2xConverter:
     the upscale function.
     """
 
-    def __init__(self, waifu2x_settings, model_dir):
-        self.waifu2x_settings = waifu2x_settings
-        self.waifu2x_settings['model_dir'] = model_dir
+    def __init__(self, settings, model_dir):
+        self.settings = settings
+        self.settings['model_dir'] = model_dir
         self.print_lock = threading.Lock()
 
     def upscale(self, input_directory, output_directory, scale_ratio, jobs, image_format, upscaler_exceptions):
@@ -46,16 +49,16 @@ class Waifu2xConverter:
 
         try:
             # overwrite config file settings
-            self.waifu2x_settings['input'] = input_directory
-            self.waifu2x_settings['output'] = output_directory
-            self.waifu2x_settings['scale-ratio'] = scale_ratio
-            self.waifu2x_settings['jobs'] = jobs
-            self.waifu2x_settings['output-format'] = image_format
+            self.settings['input'] = input_directory
+            self.settings['output'] = output_directory
+            self.settings['scale-ratio'] = scale_ratio
+            self.settings['jobs'] = jobs
+            self.settings['output-format'] = image_format
 
             # models_rgb must be specified manually for waifu2x-converter-cpp
             # if it's not specified in the arguments, create automatically
-            if self.waifu2x_settings['model-dir'] is None:
-                self.waifu2x_settings['model-dir'] = pathlib.Path(self.waifu2x_settings['waifu2x_converter_path']) / 'models_rgb'
+            if self.settings['model-dir'] is None:
+                self.settings['model-dir'] = pathlib.Path(self.settings['path']) / 'models_rgb'
 
             # print thread start message
             self.print_lock.acquire()
@@ -64,11 +67,11 @@ class Waifu2xConverter:
 
             # list to be executed
             # initialize the list with waifu2x binary path as the first element
-            execute = [str(pathlib.Path(self.waifu2x_settings['waifu2x_converter_path']) / 'waifu2x-converter-cpp.exe')]
+            execute = [common.find_path(self.settings['path'])]
 
-            for key in self.waifu2x_settings.keys():
+            for key in self.settings.keys():
 
-                value = self.waifu2x_settings[key]
+                value = self.settings[key]
 
                 # the key doesn't need to be passed in this case
                 if key == 'waifu2x_converter_path':

--- a/bin/waifu2x_converter.py
+++ b/bin/waifu2x_converter.py
@@ -77,7 +77,7 @@ class Waifu2xConverter:
 
             for key, value in self.settings.items():
                 # the key doesn't need to be passed in this case
-                if key == 'path' or key == 'binary':
+                if key in ['path', 'binary', 'win_binary']:
                     continue
 
                 # null or None means that leave this option out (keep default)

--- a/bin/waifu2x_converter.py
+++ b/bin/waifu2x_converter.py
@@ -14,7 +14,6 @@ for waifu2x-converter-cpp.
 import common
 
 # built-in imports
-import pathlib
 import subprocess
 import threading
 
@@ -31,10 +30,19 @@ class Waifu2xConverter:
     the upscale function.
     """
 
-    def __init__(self, settings, model_dir):
+    def __init__(self, settings):
         self.settings = settings
-        self.settings['model_dir'] = model_dir
         self.print_lock = threading.Lock()
+
+        # Searches for models directory
+        if 'model-dir' in self.settings:
+            model_dir = common.find_path(self.settings['model-dir'])
+
+            # Search for model folder in waifu2x-converter-cpp folder
+            if model_dir[0] is None:
+                model_dir = common.find_path(self.settings['path'] / self.settings['model-dir'])
+
+            self.settings['model-dir'] = model_dir[0]
 
     def upscale(self, input_directory, output_directory, scale_ratio, jobs, image_format, upscaler_exceptions):
         """ Waifu2x Converter Driver Upscaler
@@ -55,11 +63,6 @@ class Waifu2xConverter:
             self.settings['jobs'] = jobs
             self.settings['output-format'] = image_format
 
-            # models_rgb must be specified manually for waifu2x-converter-cpp
-            # if it's not specified in the arguments, create automatically
-            if self.settings['model-dir'] is None:
-                self.settings['model-dir'] = pathlib.Path(self.settings['path']) / 'models_rgb'
-
             # print thread start message
             self.print_lock.acquire()
             Avalon.debug_info(f'[upscaler] Thread {threading.current_thread().name} started')
@@ -67,30 +70,27 @@ class Waifu2xConverter:
 
             # list to be executed
             # initialize the list with waifu2x binary path as the first element
-            execute = [common.find_path(self.settings['path'])]
+            execute = [self.settings['path'] / self.settings['binary']]
 
-            for key in self.settings.keys():
-
-                value = self.settings[key]
-
+            for key, value in self.settings.items():
                 # the key doesn't need to be passed in this case
-                if key == 'waifu2x_converter_path':
+                if key == 'path' or key == 'binary':
                     continue
 
                 # null or None means that leave this option out (keep default)
                 elif value is None or value is False:
                     continue
+
+                if len(key) == 1:
+                    execute.append(f'-{key}')
                 else:
-                    if len(key) == 1:
-                        execute.append(f'-{key}')
-                    else:
-                        execute.append(f'--{key}')
+                    execute.append(f'--{key}')
 
-                    # true means key is an option
-                    if value is True:
-                        continue
+                # true means key is an option
+                if value is True:
+                    continue
 
-                    execute.append(str(value))
+                execute.append(str(value))
 
             Avalon.debug_info(f'Executing: {execute}')
             return subprocess.run(execute, check=True).returncode

--- a/bin/waifu2x_converter.py
+++ b/bin/waifu2x_converter.py
@@ -30,9 +30,12 @@ class Waifu2xConverter:
     the upscale function.
     """
 
-    def __init__(self, settings):
+    def __init__(self, settings, model_dir):
         self.settings = settings
         self.print_lock = threading.Lock()
+
+        if model_dir:
+            self.settings['model-dir'] = model_dir
 
         # Searches for models directory
         if 'model-dir' in self.settings:

--- a/bin/waifu2x_ncnn_vulkan.py
+++ b/bin/waifu2x_ncnn_vulkan.py
@@ -32,9 +32,12 @@ class Waifu2xNcnnVulkan:
     the upscale function.
     """
 
-    def __init__(self, settings):
+    def __init__(self, settings, model_dir):
         self.settings = settings
         self.print_lock = threading.Lock()
+
+        if model_dir:
+            self.settings['m'] = model_dir
 
         # Searches for models directory
         if 'm' in self.settings:

--- a/bin/waifu2x_ncnn_vulkan.py
+++ b/bin/waifu2x_ncnn_vulkan.py
@@ -12,6 +12,9 @@ Description: This class is a high-level wrapper
 for waifu2x_ncnn_vulkan.
 """
 
+# local imports
+import common
+
 # built-in imports
 import os
 import subprocess
@@ -30,14 +33,14 @@ class Waifu2xNcnnVulkan:
     the upscale function.
     """
 
-    def __init__(self, waifu2x_settings):
-        self.waifu2x_settings = waifu2x_settings
+    def __init__(self, settings):
+        self.settings = settings
 
         # arguments passed through command line overwrites config file values
 
         # waifu2x_ncnn_vulkan can't find its own model directory if its not in the current dir
         #   so change to it
-        os.chdir(os.path.join(self.waifu2x_settings['waifu2x_ncnn_vulkan_path'], '..'))
+        os.chdir(os.path.join(self.settings['waifu2x_ncnn_vulkan_path'], '..'))
 
         self.print_lock = threading.Lock()
 
@@ -52,9 +55,9 @@ class Waifu2xNcnnVulkan:
 
         try:
             # overwrite config file settings
-            self.waifu2x_settings['i'] = input_directory
-            self.waifu2x_settings['o'] = output_directory
-            self.waifu2x_settings['s'] = scale_ratio
+            self.settings['i'] = input_directory
+            self.settings['o'] = output_directory
+            self.settings['s'] = scale_ratio
 
             # print thread start message
             self.print_lock.acquire()
@@ -63,11 +66,11 @@ class Waifu2xNcnnVulkan:
 
             # list to be executed
             # initialize the list with waifu2x binary path as the first element
-            execute = [str(self.waifu2x_settings['waifu2x_ncnn_vulkan_path'])]
+            execute = [common.find_path(self.settings['path'])]
 
-            for key in self.waifu2x_settings.keys():
+            for key in self.settings.keys():
 
-                value = self.waifu2x_settings[key]
+                value = self.settings[key]
 
                 # is executable key or null or None means that leave this option out (keep default)
                 if key == 'waifu2x_ncnn_vulkan_path' or value is None or value is False:

--- a/bin/waifu2x_ncnn_vulkan.py
+++ b/bin/waifu2x_ncnn_vulkan.py
@@ -74,7 +74,7 @@ class Waifu2xNcnnVulkan:
             execute = [self.settings['path'] / self.settings['binary']]
 
             for key, value in self.settings.items():
-                if key == 'path' or key == 'binary':
+                if key in ['path', 'binary', 'win_binary']:
                     continue
                 # is executable key or null or None means that leave this option out (keep default)
                 if value is None or value is False:


### PR DESCRIPTION
There are a few changes in this pull request, so in order:

Bug fixes:

- There was a bug where mkvs were not fully supported, now they are.
- There was a bug where `Avalon.debug_info(pixel_formats)` would sometimes crash. fixed
- On Linux `return subprocess.run(execute, shell=True, check=True).returncode` in ffmpeg.py would crash. I'm surprised this didn't break Windows.
- Waifu2x's model_dir setting in video2x.json was being overwritten. fixed

Linux (and MacOS) support:

- Wrote a path check function (called find_path) for finding files and put it in common.py.  This works similar to how PATH works in operating systems: First check the path specified (and checks an .exe variant for Windows users), then check waifu2x/bin, then check waifu2x/, then check system's PATH.  This should work for all operating systems, doing the right thing.
- Updated video2x.json to relative paths.  find_path will find the proper absolute path if necessary.
- video2x_settings.py doesn't modify the video2x.json file's paths any more, because absolute paths are no longer required.
- All files video2x needs (ffmpeg, waifu2x-caffe, model files, ...) are searched for and verified using find_path.

Changes:

- waifu2x_ncnn_vulkan's settings in video2x.json have been changed to require less vram and to match the other drivers settings
- I tried to minimize the syntax changes, but there is a tiny bit of a difference.

Notes:

- video2x_settings.py has not been tested, as it is not required on Linux.  Though, it can be updated to support non-windows versions.
- video2x.py has not been tested on windows.  I don't have another hard drive to dual boot atm.  I recommend running it on Windows first and verifying the changes.  Please let me know if anything needs to be changed.

Want a dockerfile?  This will allow you to test without having to dual boot into Linux.  (Requires Windows 10, version 1809 or newer to support gpu acceleration.)  ^_^