### PR TITLE
Replace shlex.join method for wider compatibility

### DIFF
--- a/src/waifu2x_caffe.py
+++ b/src/waifu2x_caffe.py
@@ -12,7 +12,6 @@ for waifu2x-caffe.
 
 # built-in imports
 import os
-import shlex
 import subprocess
 import threading
 
@@ -82,6 +81,6 @@ class Waifu2xCaffe:
 
         # return the Popen object of the new process created
         self.print_lock.acquire()
-        Avalon.debug_info(f'[upscaler] Subprocess {os.getpid()} executing: {shlex.join(execute)}')
+        Avalon.debug_info(f'[upscaler] Subprocess {os.getpid()} executing: {"-".join(execute)}')
         self.print_lock.release()
         return subprocess.Popen(execute)

--- a/src/waifu2x_converter.py
+++ b/src/waifu2x_converter.py
@@ -13,7 +13,6 @@ for waifu2x-converter-cpp.
 # built-in imports
 import os
 import pathlib
-import shlex
 import subprocess
 import threading
 
@@ -87,6 +86,6 @@ class Waifu2xConverter:
 
         # return the Popen object of the new process created
         self.print_lock.acquire()
-        Avalon.debug_info(f'[upscaler] Subprocess {os.getpid()} executing: {shlex.join(execute)}')
+        Avalon.debug_info(f'[upscaler] Subprocess {os.getpid()} executing: {"-".join(execute)}')
         self.print_lock.release()
         return subprocess.Popen(execute)

--- a/src/waifu2x_ncnn_vulkan.py
+++ b/src/waifu2x_ncnn_vulkan.py
@@ -15,7 +15,6 @@ for waifu2x_ncnn_vulkan.
 
 # built-in imports
 import os
-import shlex
 import subprocess
 import threading
 
@@ -77,6 +76,6 @@ class Waifu2xNcnnVulkan:
 
         # return the Popen object of the new process created
         self.print_lock.acquire()
-        Avalon.debug_info(f'[upscaler] Subprocess {os.getpid()} executing: {shlex.join(execute)}')
+        Avalon.debug_info(f'[upscaler] Subprocess {os.getpid()} executing: {"-".join(execute)}')
         self.print_lock.release()
         return subprocess.Popen(execute)


### PR DESCRIPTION
https://docs.python.org/3/library/shlex.html

![image](https://user-images.githubusercontent.com/53661808/80650315-645ff280-8a39-11ea-9d59-b0d3e9cf4c68.png)

Python 3.8 is not yet compatible with everything, many people (including myself) are still on Python 3.7.6.

Fixes #230 
