### PR TITLE
Adjustments to return to a single requirements.txt

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           python -m pip install -U pip
           pip install -U pyinstaller pywin32
-          pip install -U -r requirements-windows.txt
+          pip install -U -r requirements.txt
       - name: Build Video2X CLI
         run: |
           pyinstaller --noconfirm --log-level=WARN `

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ RUN curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu18
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1 && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 2
 RUN cd / && python3.8 -m pip install --upgrade pip &&\
     git clone --recurse-submodules --progress https://github.com/k4yt3x/video2x.git --depth=1 &&\
-    python3.8 -m pip install -U -r video2x/src/requirements-linux.txt
+    python3.8 -m pip install -U -r video2x/src/requirements.txt
 
 # Compile drivers
 

--- a/src/build.ps1
+++ b/src/build.ps1
@@ -82,7 +82,7 @@ Copy-Item "dist\video2x.exe" -Destination "$($VIDEO2X_VERSION)\video2x-$($VIDEO2
 Copy-Item "dist\video2x_gui.exe" -Destination "$($VIDEO2X_VERSION)\video2x-$($VIDEO2X_VERSION)-win32-light\"
 Copy-Item "dist\video2x_setup.exe" -Destination "$($VIDEO2X_VERSION)\video2x-$($VIDEO2X_VERSION)-win32-light\"
 Copy-Item "video2x.yaml" -Destination "$($VIDEO2X_VERSION)\video2x-$($VIDEO2X_VERSION)-win32-light\"
-Copy-Item "requirements-windows.txt" -Destination "$($VIDEO2X_VERSION)\video2x-$($VIDEO2X_VERSION)-win32-light\"
+Copy-Item "requirements.txt" -Destination "$($VIDEO2X_VERSION)\video2x-$($VIDEO2X_VERSION)-win32-light\"
 
 # clean up temporary files
 Write-Host -ForegroundColor White "`nDeleting temporary files"

--- a/src/requirements-linux.txt
+++ b/src/requirements-linux.txt
@@ -1,8 +1,0 @@
-avalon_framework
-colorama
-patool
-pyqt5
-python-magic
-pyyaml
-requests
-tqdm

--- a/src/requirements-windows.txt
+++ b/src/requirements-windows.txt
@@ -1,9 +1,0 @@
-avalon_framework
-colorama
-patool
-pyqt5
-python-magic
-python-magic-bin
-pyyaml
-requests
-tqdm

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,0 +1,9 @@
+avalon_framework
+colorama
+patool
+pyqt5
+python-magic; platform_system != "Windows"
+python-magic-bin; platform_system == "Windows"
+pyyaml
+requests
+tqdm

--- a/src/video2x_setup.py
+++ b/src/video2x_setup.py
@@ -105,7 +105,7 @@ class Video2xSetup:
     def _install_python_requirements(self):
         """ Read requirements.txt and return its content
         """
-        pip_install('requirements-windows.txt')
+        pip_install('requirements.txt')
 
     def _cleanup(self):
         """ Cleanup all the temp files downloaded


### PR DESCRIPTION
~~python-magic 0.4.15 fixes a big for Linux builds of Python that causes Windows builds to be incompatible with even the pre-compiled binaries. This fixes the issue as well as~~ makes it viable to return to a single requirements.txt file.