### PR TITLE
Fixed issue where if hwaccel value in config is overwritten with auto

### DIFF
--- a/src/video2x_gui.py
+++ b/src/video2x_gui.py
@@ -684,9 +684,7 @@ class Video2XMainWindow(QMainWindow):
 
         # extract frames
         self.config['ffmpeg']['extract_frames']['output_options']['-pix_fmt'] = self.ffmpeg_extract_frames_output_options_pixel_format_line_edit.text()
-        if self.ffmpeg_extract_frames_hardware_acceleration_check_box.isChecked():
-            self.config['ffmpeg']['extract_frames']['-hwaccel'] = 'auto'
-        else:
+        if not self.ffmpeg_extract_frames_hardware_acceleration_check_box.isChecked():
             self.config['ffmpeg']['extract_frames'].pop('-hwaccel', None)
 
         # assemble video
@@ -712,9 +710,7 @@ class Video2XMainWindow(QMainWindow):
         else:
             self.config['ffmpeg']['assemble_video']['output_options'].pop('-vf', None)
 
-        if self.ffmpeg_assemble_video_hardware_acceleration_check_box.isChecked():
-            self.config['ffmpeg']['assemble_video']['-hwaccel'] = 'auto'
-        else:
+        if not self.ffmpeg_assemble_video_hardware_acceleration_check_box.isChecked():
             self.config['ffmpeg']['assemble_video'].pop('-hwaccel', None)
 
         # migrate streams
@@ -768,9 +764,7 @@ class Video2XMainWindow(QMainWindow):
             self.config['ffmpeg']['migrate_streams']['output_options'].pop('-movflags', None)
 
         # hardware acceleration
-        if self.ffmpeg_migrate_streams_hardware_acceleration_check_box.isChecked():
-            self.config['ffmpeg']['migrate_streams']['-hwaccel'] = 'auto'
-        else:
+        if not self.ffmpeg_migrate_streams_hardware_acceleration_check_box.isChecked():
             self.config['ffmpeg']['migrate_streams'].pop('-hwaccel', None)
 
         # Gifski


### PR DESCRIPTION
Currently when the config.yml hwaccel is set to anything other than auto it is overwritten, this allows advanced user's to specify the specific hwaccel in the yaml without having to find a hack to get around the hardcoded values