### PR TITLE
Add 'import sys' to anime4kcpp.py wrapper

### DIFF
--- a/src/wrappers/anime4kcpp.py
+++ b/src/wrappers/anime4kcpp.py
@@ -11,6 +11,7 @@ for Anime4KCPP.
 """
 
 # built-in imports
+import sys
 import argparse
 import os
 import pathlib

--- a/src/wrappers/anime4kcpp.py
+++ b/src/wrappers/anime4kcpp.py
@@ -4,19 +4,22 @@
 Name: Anime4KCPP Driver
 Author: K4YT3X
 Date Created: May 3, 2020
-Last Modified: September 9, 2020
+Last Modified: December 15, 2020
+
+Editor: fire0shadow
+Last Modified: December 15, 2020
 
 Description: This class is a high-level wrapper
 for Anime4KCPP.
 """
 
 # built-in imports
-import sys
 import argparse
 import os
 import pathlib
 import platform
 import subprocess
+import sys
 import threading
 
 # third-party imports


### PR DESCRIPTION
Without 'import sys' at the beginning of the file, script fails to run with NameError exception. Part of error log attached.

[video2x_error.log](https://github.com/k4yt3x/video2x/files/5690170/video2x_error.log)