### PR TITLE
Fix Docker image build by using Ubuntu old-release apt repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ LABEL maintainer="Danielle Douglas <ddouglas87@gmail.com>"
 LABEL maintainer="Lhanjian <lhjay1@foxmail.com>"
 LABEL maintainer="K4YT3X <k4yt3x@k4yt3x.com>"
 
+RUN sed -i 's/archive.ubuntu.com/old-releases.ubuntu.com/g' sources.list
+RUN sed -i 's/security.ubuntu.com/old-releases.ubuntu.com/g' sources.list
+
 # run installation
 RUN apt-get update \
     && apt-get install -y git-core \


### PR DESCRIPTION
[Ubuntu 19.10 is EOL 7 months ago](https://endoflife.date/ubuntu), but due to compatibility issue, the base image of the Dockerfile wasn't upgraded to newer Ubuntu yet, and a standard apt repository site won't be reachable in this case, which makes the Docker image not able to be built. Before the base image upgrade, a workaround to use old-releases apt repository can make the image be able to be built again.

The error before the fix:

```sh
~/video2x $ docker build -t video2x .
Sending build context to Docker daemon  12.26MB  
Step 1/9 : FROM ubuntu:19.10                              
 ---> 2f6c85efea61                  
Step 2/9 : LABEL maintainer="Danielle Douglas <ddouglas87@gmail.com>"
 ---> Using cache
 ---> f0f2280048e0
Step 3/9 : LABEL maintainer="Lhanjian <lhjay1@foxmail.com>"                 
 ---> Using cache                                
 ---> c910599ff0c3                            
Step 4/9 : LABEL maintainer="K4YT3X <k4yt3x@k4yt3x.com>"
 ---> Using cache                                                        
 ---> d76ae4d10e94                                                        
Step 5/9 : RUN apt-get update     && apt-get install -y git-core     && git clone --recurse-submodules --progress https://github.com/k4yt3x/video2x.git /tmp/video2x/video2x     && bash -e /tmp/video2x/video2x/src/video2x_setup_ubuntu.sh /
 ---> Running in edfda1d7b4f5
Ign:1 http://security.ubuntu.com/ubuntu eoan-security InRelease
Ign:2 http://archive.ubuntu.com/ubuntu eoan InRelease
Err:3 http://security.ubuntu.com/ubuntu eoan-security Release
  404  Not Found [IP: 91.189.91.38 80]     
Ign:4 http://archive.ubuntu.com/ubuntu eoan-updates InRelease
Ign:5 http://archive.ubuntu.com/ubuntu eoan-backports InRelease
Err:6 http://archive.ubuntu.com/ubuntu eoan Release
  404  Not Found [IP: 91.189.88.152 80]                     
Err:7 http://archive.ubuntu.com/ubuntu eoan-updates Release            
  404  Not Found [IP: 91.189.88.152 80]
Err:8 http://archive.ubuntu.com/ubuntu eoan-backports Release
  404  Not Found [IP: 91.189.88.152 80]                          
Reading package lists...              
E: The repository 'http://security.ubuntu.com/ubuntu eoan-security Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu eoan Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu eoan-updates Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu eoan-backports Release' does not have a Release file.
The command '/bin/sh -c apt-get update     && apt-get install -y git-core     && git clone --recurse-submodules --progress https://github.com/k4yt3x/video2x.git /tmp/video2x/video2x     && bash -e /tmp/video2x/video2x/src/video2x_setup_ub
untu.sh /' returned a non-zero code: 100
```