### PR TITLE
ffmpeg can crash if source title has subtitles

### DIFF
--- a/video2x/encoder.py
+++ b/video2x/encoder.py
@@ -108,6 +108,7 @@ class VideoEncoder(threading.Thread):
                     *[s for s in additional_streams if s is not None],
                     str(self.output_path),
                     vcodec="libx264",
+                    scodec="copy",
                     vsync="cfr",
                     pix_fmt="yuv420p",
                     crf=17,


### PR DESCRIPTION
I was trying to upscale a dvd rip this evening and kept running into a crash from ffmpeg, it looks like the default ffmpeg.output() options map the subtitles properly but the default (to ffmpeg) behavior is to try and convert them, I added an explicit copy in encoder.py and it happily fixes the crash.