### PR TITLE
Fixed interpolation algorithms list

### DIFF
--- a/video2x/video2x.py
+++ b/video2x/video2x.py
@@ -545,7 +545,7 @@ def parse_arguments() -> argparse.Namespace:
     interpolate.add_argument(
         "-a",
         "--algorithm",
-        choices=UPSCALING_ALGORITHMS,
+        choices=INTERPOLATION_ALGORITHMS,
         help="algorithm to use for upscaling",
         default=INTERPOLATION_ALGORITHMS[0],
     )


### PR DESCRIPTION
When trying to do interpolation, only upscaling algorithms are accepted as command line arguments. This is a fix, tested in a docker container. 