### PR TITLE
feat(encoder): copy language tag for audio and subtitle streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Multi-versioning to critical functions to enhance performance in generic architecture builds.
+- The feature to copy input streams' metadata to the output streams (#1282).
 
 ### Changed
 

--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -225,7 +225,7 @@ int Encoder::init(
                 return AVERROR_UNKNOWN;
             }
 
-            // Copy codec parameters from input to output
+            // Copy codec parameters from the input stream to the output stream
             ret = avcodec_parameters_copy(out_stream->codecpar, in_codecpar);
             if (ret < 0) {
                 logger()->error("Failed to copy codec parameters");
@@ -233,10 +233,11 @@ int Encoder::init(
             }
             out_stream->codecpar->codec_tag = 0;
 
-            // Copy language tag if available
-            AVDictionaryEntry * lang_entry = av_dict_get(in_stream->metadata, "language", nullptr, 0);
-            if(lang_entry) {
-                av_dict_set(&out_stream->metadata, lang_entry->key, lang_entry->value, 0);
+            // Copy all metadata from the input stream to the output stream
+            AVDictionaryEntry* tag = nullptr;
+            while ((tag = av_dict_get(in_stream->metadata, "", tag, AV_DICT_IGNORE_SUFFIX)) !=
+                   nullptr) {
+                av_dict_set(&out_stream->metadata, tag->key, tag->value, 0);
             }
 
             // Copy time base

--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -233,6 +233,12 @@ int Encoder::init(
             }
             out_stream->codecpar->codec_tag = 0;
 
+            // Copy language tag if available
+            AVDictionaryEntry * lang_entry = av_dict_get(in_stream->metadata, "language", nullptr, 0);
+            if(lang_entry) {
+                av_dict_set(&out_stream->metadata, lang_entry->key, lang_entry->value, 0);
+            }
+
             // Copy time base
             out_stream->time_base = in_stream->time_base;
 


### PR DESCRIPTION
Containers with audio streams for different languages use a tag to signal which track contains which language. This information is saved in the metadata object of a stream and needs to be copied in addition to the codec properties.