### PR TITLE
Modify the output option under General options to make it optional.

### DIFF
--- a/docs/book/src/building/windows.md
+++ b/docs/book/src/building/windows.md
@@ -48,7 +48,7 @@ Rename-Item -Path "third_party/ncnn-$ncnnVersion-windows-vs2022-shared" -NewName
 ## 4. Build the Project
 
 ```bash
-cmake -S . -B build -DUSE_SYSTEM_NCNN=OFF -DUSE_SYSTEM_SPDLOG=OFF -DUSE_SYSTEM_BOOST=OFF `
+cmake -S . -B build -DVIDEO2X_USE_EXTERNAL_NCNN=OFF -DVIDEO2X_USE_EXTERNAL_SPDLOG=OFF -DVIDEO2X_USE_EXTERNAL_BOOST=OFF `
   -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/libvideo2x-shared
 cmake --build build --config Release --parallel --target install
 ```

--- a/tools/video2x/src/argparse.cpp
+++ b/tools/video2x/src/argparse.cpp
@@ -161,8 +161,7 @@ int parse_args(
             ("realesrgan-model", PO_STR_VALUE<video2x::fsutils::StringType>()
                 ->default_value(STR("realesr-animevideov3"), "realesr-animevideov3")
                 ->notifier(validate_realesrgan_model_name),
-                "Name of the RealESRGAN model to use (realesr-animevideov3, realesrgan-plus-anime, "
-                "realesrgan-plus)")
+                "Name of the RealESRGAN model to use (must start with \"realesr\", case insensitive).")
         ;
 
         po::options_description realcugan_opts("RealCUGAN options");

--- a/tools/video2x/src/argparse.cpp
+++ b/tools/video2x/src/argparse.cpp
@@ -132,7 +132,7 @@ int parse_args(
             ("height,h", po::value<int>(&proc_cfg.height)
                 ->notifier([](int v) { validate_greater_equal_one(v, "height"); }), "Output height")
             ("scaling-factor,s", po::value<int>(&proc_cfg.scaling_factor)
-                ->notifier([](int v) { validate_min(v, "scaling-factor", 2); }), "Scaling factor")
+                ->notifier([](int v) { validate_min(v, "scaling-factor", 1); }), "Scaling factor")
             ("noise-level,n", po::value<int>(&proc_cfg.noise_level)
                 ->notifier([](int v) { validate_min(v, "noise-level", 0); }), "Noise level")
         ;
@@ -387,7 +387,7 @@ int parse_args(
                     );
                     return -1;
                 }
-                if (proc_cfg.scaling_factor < 2 || proc_cfg.scaling_factor > 4) {
+                if (proc_cfg.scaling_factor < 1 || proc_cfg.scaling_factor > 4) {
                     video2x::logger()->critical(
                         "Scaling factor must be set to 2, 3, or 4 for RealESRGAN."
                     );

--- a/tools/video2x/src/argparse.cpp
+++ b/tools/video2x/src/argparse.cpp
@@ -78,8 +78,8 @@ int parse_args(
             // General Processing Options
             ("input,i", PO_STR_VALUE<video2x::fsutils::StringType>()->required(),
                 "Input video file path")
-            ("output,o", PO_STR_VALUE<video2x::fsutils::StringType>()->required(),
-                "Output video file path")
+            ("output,o", PO_STR_VALUE<video2x::fsutils::StringType>(),
+                "Output video file path (if not specified, the input file name will be used by default)")
             ("processor,p", PO_STR_VALUE<video2x::fsutils::StringType>()->required(),
                 "Processor to use (libplacebo, realesrgan, realcugan, rife)")
             ("hwaccel,a", PO_STR_VALUE<video2x::fsutils::StringType>()
@@ -268,9 +268,8 @@ int parse_args(
         if (vm.count("output")) {
             arguments.out_fname =
                 std::filesystem::path(vm["output"].as<video2x::fsutils::StringType>());
-        } else if (!arguments.benchmark) {
-            video2x::logger()->critical("Output file path is required.");
-            return -1;
+        } else {
+            arguments.out_fname = arguments.in_fname.filename();  // Extract file name only
         }
 
         // Parse processor type

--- a/tools/video2x/src/validators.cpp
+++ b/tools/video2x/src/validators.cpp
@@ -23,15 +23,18 @@ void validate_anime4k_shader_name(const video2x::fsutils::StringType& shader_nam
 }
 
 void validate_realesrgan_model_name(const video2x::fsutils::StringType& model_name) {
-    static const std::unordered_set<video2x::fsutils::StringType> valid_realesrgan_models = {
-        STR("realesrgan-plus"), STR("realesrgan-plus-anime"), STR("realesr-animevideov3")
-    };
-    if (valid_realesrgan_models.count(model_name) == 0) {
+    // Convert the input model name to lowercase
+    video2x::fsutils::StringType lower_model_name = model_name;
+    std::transform(
+        lower_model_name.begin(), lower_model_name.end(), lower_model_name.begin(), ::tolower
+    );
+
+    // Check if the model name starts with "realesr" (case insensitive)
+    if (lower_model_name.find(STR("realesr")) != 0) {
         throw po::validation_error(
             po::validation_error::invalid_option_value,
             "realesrgan-model",
-            "realesrgan-model must be one of: realesr-animevideov3, realesrgan-plus-anime, "
-            "realesrgan-plus"
+            "realesrgan-model must start with 'realesr' (case insensitive)"
         );
     }
 }


### PR DESCRIPTION
If no output is provided, the input file name will be used as the default.

The original program required the output file path as a mandatory option, which was somewhat inconvenient. Therefore, I modified it to make it optional, with the default value set to the input file name.