### PR TITLE
Resolve issue with missing libomp in docker builds.

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -38,7 +38,7 @@ ENV VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/nvidia_icd.json\
 
 COPY --from=builder /tmp/video2x.pkg.tar.zst /video2x.pkg.tar.zst
 RUN pacman -Sy --noconfirm nvidia-utils vulkan-radeon vulkan-intel vulkan-swrast \
-        ffmpeg ncnn spdlog boost-libs \
+        ffmpeg ncnn openmp spdlog boost-libs \
     && pacman -U --noconfirm /video2x.pkg.tar.zst \
     && rm -rf /video2x.pkg.tar.zst /var/cache/pacman/pkg/*
 


### PR DESCRIPTION
Docker builds reported that a shared library "libomp.so" was missing.

Added missing dependency to resolve this.