### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM archlinux:base-devel
+RUN pacman -Syu --noconfirm cmake ninja boost ffmpeg ncnn openmp spdlog vulkan-driver vulkan-headers
+RUN mkdir /source
+WORKDIR /source
+COPY . /source
+RUN cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=/usr
+RUN ninja -C build install
+RUN tar -cf video2x.tar -T build/install_manifest.txt
+
+FROM archlinux:base
+RUN pacman -Suy --noconfirm boost-libs ffmpeg ncnn openmp spdlog vulkan-driver
+COPY --from=0 /source/video2x.tar /
+RUN tar -xf /video2x.tar && rm /video2x.tar
+CMD ["/usr/bin/video2x"]


### PR DESCRIPTION
This pull request adds a simple Dockerfile in a two-phase build: the first phase builds the actual binaries, while the second one builds the actual image that is used. Data is transferred from the first phase to the second one by archiving everything inside the generated `install_manifest.txt`.

> [!WARNING]
>
> This change currently requires a patch described in #1423 in order to work.

