### PR TITLE
fix: destroy the ncnn GPU instance before exit instead of during DLL unload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
           submodules: recursive
 
       - name: Install Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.0
+        uses: humbletim/setup-vulkan-sdk@v1.2.1
         with:
           vulkan-query-version: 1.3.204.0
           vulkan-components: Vulkan-Headers, Vulkan-Loader, Glslang, SPIRV-Tools, SPIRV-Headers

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Install Vulkan SDK
         uses: humbletim/setup-vulkan-sdk@v1.2.1
         with:
-          vulkan-query-version: 1.3.204.0
+          vulkan-query-version: 1.4.313.0
           vulkan-components: Vulkan-Headers, Vulkan-Loader, Glslang, SPIRV-Tools, SPIRV-Headers
           vulkan-use-cache: true
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,13 +483,20 @@ if(VIDEO2X_BUILD_CLI)
             "${CMAKE_BINARY_DIR}/third_party/boost/libs/program_options/${CMAKE_BUILD_TYPE}"
         )
 
-        # Different build types have different DLL names
-        if(CMAKE_BUILD_TYPE STREQUAL Release)
-            set(boost_dll_path "${boost_base_path}/boost_program_options-vc143-mt-x64-1_86.dll")
-        else()
-            set(boost_dll_path "${boost_base_path}/boost_program_options-vc143-mt-gd-x64-1_86.dll")
-        endif()
-
-        install(FILES "${boost_dll_path}" DESTINATION "${CMAKE_INSTALL_BINDIR}")
+        # Match the DLL by pattern instead of spelling out its name. Boost encodes the MSVC toolset
+        # and the build variant into the file name - boost_program_options-vc143-mt-gd-x64-1_86.dll -
+        # so a hard-coded "vc143" breaks the moment the runner ships a newer Visual Studio. That is
+        # exactly what happened: windows-latest now has VS 18, Boost builds as vc180, and the install
+        # step fails with "file INSTALL cannot find ...-vc143-...dll" AFTER everything has already
+        # compiled and linked.
+        #
+        # install(DIRECTORY ... FILES_MATCHING) is evaluated at install time, not at configure time,
+        # which is what lets the glob see a DLL that does not exist yet when CMake runs.
+        install(
+            DIRECTORY "${boost_base_path}/"
+            DESTINATION "${CMAKE_INSTALL_BINDIR}"
+            FILES_MATCHING
+            PATTERN "boost_program_options-*.dll"
+        )
     endif()
 endif()

--- a/include/libvideo2x/libvideo2x.h
+++ b/include/libvideo2x/libvideo2x.h
@@ -17,6 +17,20 @@ extern "C" {
 
 namespace video2x {
 
+/// Releases the GPU resources held by the ncnn backend.
+///
+/// Call this once from the application, before it exits. Leaving the teardown to ncnn's own static
+/// destructor crashes the process on Windows, where ncnn is linked as a shared library: the teardown
+/// then runs while the loader is already unloading DLLs. See the implementation in src/libvideo2x.cpp
+/// for the full explanation.
+///
+/// Safe to call when no GPU resources were ever allocated - the libplacebo path, `--help`, a failed
+/// argument parse - and safe to call more than once.
+///
+/// Must NOT be called while a VideoProcessor is still processing: it destroys the Vulkan instance the
+/// processor's buffers were allocated from.
+LIBVIDEO2X_API void release_gpu_resources();
+
 enum class VideoProcessorState {
     Idle,
     Running,

--- a/src/libvideo2x.cpp
+++ b/src/libvideo2x.cpp
@@ -5,6 +5,7 @@ extern "C" {
 #include <libavutil/avutil.h>
 }
 
+#include <gpu.h>
 #include <spdlog/spdlog.h>
 
 #include "avutils.h"
@@ -15,6 +16,40 @@ extern "C" {
 #include "processor_factory.h"
 
 namespace video2x {
+
+void release_gpu_resources() {
+    // ncnn creates its Vulkan instance lazily, on first use, and never tears it down on request. It
+    // only does so from a static destructor (__ncnn_vulkan_instance_holder) plus an atexit() handler
+    // that create_gpu_instance() registers inside ncnn itself.
+    //
+    // On Windows that is too late. ncnn is linked as a SHARED library here - see CMakeLists.txt,
+    // "Use the pre-built shared ncnn library on Windows" - so both of those run while the loader is
+    // already unloading DLLs at process exit. Calling into another DLL at that point is documented as
+    // unsafe, and the teardown does exactly that: vkDeviceWaitIdle(), vkDestroyInstance() and
+    // glslang::FinalizeProcess() all reach into code that may already be gone.
+    //
+    // The result is an access violation AFTER main() has returned. video2x prints "Video processed
+    // successfully", writes its complete processing summary, and only then dies with a segfault - so
+    // a successful run and a failed one are indistinguishable by exit code, and every script driving
+    // video2x has to ignore the exit code and inspect the output file instead. Windows Error
+    // Reporting does not even log the crash, because it happens inside the loader teardown, which is
+    // why it is so easy to mistake for a fluke of the environment.
+    //
+    // ncnn's author is aware of the hazard. gpu.cpp carries this comment next to the atexit() call:
+    //
+    //     // the global __ncnn_vulkan_instance_holder destructor will call destroy_gpu_instance() on
+    //     // exit
+    //     // atexit() seems to be helpful for calling it earlier    --- nihui
+    //
+    // and his own reference tools (rife-ncnn-vulkan, realesrgan-ncnn-vulkan) call
+    // destroy_gpu_instance() explicitly from main() rather than relying on that teardown.
+    //
+    // So do the same: destroy the instance here, while every DLL is still loaded and the process is
+    // healthy. destroy_gpu_instance() returns immediately when no instance was ever created, so this
+    // is a no-op for the libplacebo path, and ncnn's own atexit handler and static destructor still
+    // run afterwards without doing any harm.
+    ncnn::destroy_gpu_instance();
+}
 
 VideoProcessor::VideoProcessor(
     const processors::ProcessorConfig proc_cfg,

--- a/tools/video2x/src/video2x.cpp
+++ b/tools/video2x/src/video2x.cpp
@@ -39,6 +39,18 @@ std::tuple<int, int, int> calculate_time_components(int time_elapsed) {
     return {hours_elapsed, minutes_elapsed, seconds_elapsed};
 }
 
+// Releases the GPU resources on every exit path of main(), while the process is still healthy.
+//
+// Left to ncnn's own static teardown, this runs during DLL unload at process exit and crashes with an
+// access violation - after the summary has already been printed, so the run looks successful and the
+// exit code says otherwise. See video2x::release_gpu_resources().
+//
+// It is declared before the VideoProcessor in main(), so it is destroyed after it: the processor's
+// Vulkan buffers must be gone before the instance they came from is.
+struct GpuResourceGuard {
+    ~GpuResourceGuard() { video2x::release_gpu_resources(); }
+};
+
 #ifdef _WIN32
 int wmain(int argc, wchar_t* argv[]) {
     // Set console output code page to UTF-8
@@ -53,6 +65,9 @@ int wmain(int argc, wchar_t* argv[]) {
 #else
 int main(int argc, char** argv) {
 #endif
+    // First local in the function, so it is destroyed last - after the VideoProcessor below.
+    GpuResourceGuard gpu_resource_guard;
+
     // Initialize newline-safe logger with custom formatting pattern
     std::shared_ptr<newline_safe_sink> logger_sink = std::make_shared<newline_safe_sink>();
     std::vector<spdlog::sink_ptr> sinks = {logger_sink};


### PR DESCRIPTION
## The bug

`video2x` always terminates with a segmentation fault — **even when the run succeeds**. It prints `Video processed successfully`, writes its complete processing summary, and only then dies:

```
[info] Video processed successfully
====== Video2X Processing summary ======
Total frames processed: 2309
Output written to: ...-part1.mp4
...
line 173: 32464 Segmentation fault      video2x.exe -i ... -p rife ...
```

A successful run and a failed one are therefore **indistinguishable by exit code**, so every script driving video2x has to ignore the exit code and inspect the output file instead. That is a bad contract for a CLI tool.

## Cause

Nothing ever destroys ncnn's Vulkan instance on purpose. ncnn creates it lazily on first use and only tears it down from its static `__ncnn_vulkan_instance_holder` destructor plus an `atexit()` handler it registers itself.

On Windows that is too late. **ncnn is a shared library here** — `CMakeLists.txt` says *"Use the pre-built shared ncnn library on Windows"*, and `build.yml` fetches `ncnn-*-windows-vs2022-shared.zip` — so both of those run while the loader is already unloading DLLs at process exit. Calling into another DLL at that point is documented as unsafe, and the teardown does exactly that: `vkDeviceWaitIdle()`, `vkDestroyInstance()` and `glslang::FinalizeProcess()`.

The access violation therefore lands *after* `main()` has returned, which is also why Windows Error Reporting never logs it — it happens inside the loader teardown.

ncnn's author is aware of the hazard. `gpu.cpp` carries this comment next to the `atexit()` call:

```cpp
// the global __ncnn_vulkan_instance_holder destructor will call destroy_gpu_instance() on exit
// atexit() seems to be helpful for calling it earlier    --- nihui
```

and his own reference tools (`rife-ncnn-vulkan`, `realesrgan-ncnn-vulkan`) call `destroy_gpu_instance()` explicitly from `main()` rather than relying on that teardown.

## The fix

Do the same. `libvideo2x` gains `video2x::release_gpu_resources()`, and the CLI calls it from an RAII guard declared as the first local in `main()` — so it fires on every exit path, and is destroyed *after* the `VideoProcessor`: the processor's Vulkan buffers must be gone before the instance they came from is.

`destroy_gpu_instance()` returns immediately when no instance was ever created, so this is a no-op for the libplacebo path, for `--help`, and for a failed argument parse. ncnn's own `atexit` handler still runs afterwards and finds nothing to do.

## Evidence

I built two Windows **Release** binaries from this workflow whose *only* difference is the 64-line fix, and ran both on the same clip:

| | RIFE (`-p rife -m 2`) | Real-ESRGAN (`-p realesrgan -s 2`) |
|---|---|---|
| unpatched `6.4.0` | `139`, `139`, `139` | `139` |
| with this fix | `0`, `0`, `0` | `0` |

The produced videos are **byte-identical** (same MD5) — the fix changes the exit code and nothing else.

## About the first three commits

They are not padding: **the Windows job cannot currently build at all**, so without them this PR would arrive with red CI and the fix could not be verified by anyone.

1. `setup-vulkan-sdk@v1.2.0` pulls `actions/cache@v2`, which GitHub now auto-fails → bumped to `v1.2.1`.
2. The pinned Vulkan SDK `1.3.204.0` (2021) declares `cmake_minimum_required` below 3.5, which CMake 4 — now on `windows-latest` — refuses outright → bumped to `1.4.313.0`.
3. `CMakeLists.txt` spells out the Boost DLL as `vc143`; `windows-latest` now builds it as `vc145`, so `install` fails *after* everything has compiled and linked → matched by pattern instead.

Happy to split those into a separate PR if you would rather review them apart.

## Caveat

Tested on Windows 11 with an RTX 5070 Ti. I have no stack trace from a debug build — the diagnosis rests on the observed behaviour, on the source, and on the control experiment above. Corrections welcome.
